### PR TITLE
Feat: 챌린지 생성 및 참여 기능 구현

### DIFF
--- a/src/main/java/snapmeal/snapmeal/domain/ChallengeReviews.java
+++ b/src/main/java/snapmeal/snapmeal/domain/ChallengeReviews.java
@@ -1,0 +1,45 @@
+package snapmeal.snapmeal.domain;
+
+import jakarta.persistence.*;
+        import lombok.*;
+import snapmeal.snapmeal.domain.common.BaseEntity;
+
+/**
+ * 챌린지 후기/별점 엔티티
+ */
+@Entity
+@Table(name = "challenge_reviews")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChallengeReviews extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    private Long reviewId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id", nullable = false)
+    private Challenges challenge;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 1~5점
+    @Setter
+    @Column(name = "rating", nullable = false)
+    private Integer rating;
+
+    // 후기 내용
+    @Setter
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    public void update(Integer newRating, String newContent) {
+        if (newRating != null) this.rating = newRating;
+        this.content = newContent;
+    }
+}

--- a/src/main/java/snapmeal/snapmeal/domain/Challenges.java
+++ b/src/main/java/snapmeal/snapmeal/domain/Challenges.java
@@ -1,0 +1,98 @@
+package snapmeal.snapmeal.domain;
+
+import jakarta.persistence.*;
+        import lombok.*;
+        import snapmeal.snapmeal.domain.User;
+import snapmeal.snapmeal.domain.common.BaseEntity;
+import snapmeal.snapmeal.domain.enums.ChallengeStatus;
+
+/**
+ * 주당 3개 생성되는 "음식 기반 챌린지" 엔티티
+ * - BaseEntity를 상속해서 createdAt/updatedAt 자동 관리
+ * - 컬럼/조인 컬럼은 스네이크 케이스로 명시
+ */
+@Entity
+@Table(name = "challenges")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Challenges extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "challenge_id")
+    private Long challengeId;
+
+    /** 소유자 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id") // 스타일 통일
+    private User user;
+
+    /** 챌린지 제목(예: "커피 마시기") */
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    /** 성공 판정용 타겟 메뉴 키워드(식사기록 menu 에 포함되면 성공) */
+    @Column(name = "target_menu_name", nullable = false, length = 100)
+    private String targetMenuName;
+
+    /** 간단 설명 */
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    /** 유효기간(포함 범위: start_date ~ end_date 23:59:59) */
+    @Column(name = "start_date")
+    private java.time.LocalDate startDate;
+
+    @Column(name = "end_date")
+    private java.time.LocalDate endDate;
+
+    /** 상태 */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private ChallengeStatus status;
+
+    /** 참여/완료/취소 타임스탬프 (표시용) */
+    @Column(name = "participated_at")
+    private java.time.LocalDateTime participatedAt;
+
+    @Column(name = "completed_at")
+    private java.time.LocalDateTime completedAt;
+
+    @Column(name = "cancelled_at")
+    private java.time.LocalDateTime cancelledAt;
+
+    // ====== 도메인 메서드: 상태 전환 로직(서비스에서 재사용) ======
+
+    /** 사용자가 "참여하기" 버튼을 눌렀을 때 호출 */
+    public void participate() {
+        if (this.status != ChallengeStatus.PENDING) {
+            throw new IllegalStateException("현재 상태에서는 참여할 수 없어요.");
+        }
+        this.status = ChallengeStatus.IN_PROGRESS;
+        this.participatedAt = java.time.LocalDateTime.now();
+    }
+
+    /** 사용자가 "포기" 버튼을 눌렀을 때 호출 */
+    public void giveUp() {
+        if (this.status != ChallengeStatus.IN_PROGRESS) {
+            throw new IllegalStateException("도전 중(IN_PROGRESS) 상태에서만 포기할 수 있어요.");
+        }
+        this.status = ChallengeStatus.CANCELLED;
+        this.cancelledAt = java.time.LocalDateTime.now();
+    }
+
+    /** 자정 배치에서 성공 판정 시 호출 */
+    public void success(java.time.LocalDateTime when) {
+        this.status = ChallengeStatus.SUCCESS;
+        this.completedAt = when;
+    }
+
+    /** 기간 종료 시 실패로 마감 */
+    public void fail() {
+        if (this.status == ChallengeStatus.PENDING || this.status == ChallengeStatus.IN_PROGRESS) {
+            this.status = ChallengeStatus.FAIL;
+        }
+    }
+}

--- a/src/main/java/snapmeal/snapmeal/domain/Meals.java
+++ b/src/main/java/snapmeal/snapmeal/domain/Meals.java
@@ -47,4 +47,7 @@ public class Meals extends BaseEntity {
         this.memo = memo;
         this.location = location;
     }
+
+    @Column(name = "menu")
+    private String menu;
 }

--- a/src/main/java/snapmeal/snapmeal/domain/enums/ChallengeStatus.java
+++ b/src/main/java/snapmeal/snapmeal/domain/enums/ChallengeStatus.java
@@ -1,0 +1,9 @@
+package snapmeal.snapmeal.domain.enums;
+
+public enum ChallengeStatus {
+        PENDING,       // 만들어졌지만 아직 참여 버튼을 안 눌렀음 (주당 3개가 여기에 해당)
+        IN_PROGRESS,   // 사용자가 참여 버튼을 눌러 도전 중
+        SUCCESS,       // 성공(자정 배치가 식사기록을 보고 성공으로 판정)
+        FAIL,          // 기간 끝났는데 성공 못함
+        CANCELLED      // 사용자가 포기하기 버튼을 눌러 취소
+}

--- a/src/main/java/snapmeal/snapmeal/repository/ChallengeRepository.java
+++ b/src/main/java/snapmeal/snapmeal/repository/ChallengeRepository.java
@@ -1,0 +1,23 @@
+// ChallengeRepository.java
+package snapmeal.snapmeal.repository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import snapmeal.snapmeal.domain.User;
+import snapmeal.snapmeal.domain.Challenges;
+import snapmeal.snapmeal.domain.enums.ChallengeStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface ChallengeRepository extends JpaRepository<Challenges, Long> {
+
+    List<Challenges> findAllByUserAndStatusIn(User user, List<ChallengeStatus> statuses);
+
+    List<Challenges> findAllByStatusInAndEndDateLessThanEqual(List<ChallengeStatus> statuses, LocalDate endDate);
+
+    List<Challenges> findAllByUserAndStartDateGreaterThanEqualAndEndDateLessThanEqual(User user, LocalDate start, LocalDate end);
+
+    Optional<Challenges> findByChallengeIdAndUser(Long challengeId, User user);
+
+    boolean existsByUserAndStartDateGreaterThanEqualAndEndDateLessThanEqual(User user, LocalDate start, LocalDate end);
+}

--- a/src/main/java/snapmeal/snapmeal/repository/ChallengeReviewRepository.java
+++ b/src/main/java/snapmeal/snapmeal/repository/ChallengeReviewRepository.java
@@ -1,0 +1,13 @@
+package snapmeal.snapmeal.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import snapmeal.snapmeal.domain.User;
+import snapmeal.snapmeal.domain.Challenges;
+import snapmeal.snapmeal.domain.ChallengeReviews;
+
+import java.util.List;
+
+public interface ChallengeReviewRepository extends JpaRepository<ChallengeReviews, Long> {
+    List<ChallengeReviews> findAllByChallenge(Challenges challenge);
+    List<ChallengeReviews> findAllByUser(User user);
+}

--- a/src/main/java/snapmeal/snapmeal/repository/MealsRepository.java
+++ b/src/main/java/snapmeal/snapmeal/repository/MealsRepository.java
@@ -10,4 +10,11 @@ import java.util.List;
 
 public interface MealsRepository extends JpaRepository<Meals, Long> {
     List<Meals> findAllByUser(User user);
+
+    boolean existsByUserAndMealDateBetweenAndMenuContainingIgnoreCase(
+            snapmeal.snapmeal.domain.User user,
+            java.time.LocalDateTime startInclusive,
+            java.time.LocalDateTime endInclusive,
+            String targetKeyword
+    );
 }

--- a/src/main/java/snapmeal/snapmeal/service/ChallengeGeneratorService.java
+++ b/src/main/java/snapmeal/snapmeal/service/ChallengeGeneratorService.java
@@ -1,0 +1,121 @@
+package snapmeal.snapmeal.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import snapmeal.snapmeal.domain.Challenges;
+import snapmeal.snapmeal.domain.User;
+import snapmeal.snapmeal.domain.enums.ChallengeStatus;
+import snapmeal.snapmeal.global.OpenAiClient;
+import snapmeal.snapmeal.repository.ChallengeRepository;
+import snapmeal.snapmeal.web.dto.ChallengeAiResponse;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChallengeGeneratorService {
+
+    private final ChallengeRepository challengeRepository;
+    private final OpenAiClient openAiClient;           // 주입 위치/타입 PR과 동일
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final List<String> FALLBACK_MENUS = List.of(
+            "아메리카노","라떼","요거트","사과","바나나",
+            "고구마","그릭요거트","샐러드","두부","삶은계란"
+    );
+
+    // 이번 주(weekStart~weekEnd) 챌린지가 이미 있으면 재생성하지 않음
+    @Transactional
+    public List<Challenges> generateWeeklyForUser(User user, LocalDate weekStart, LocalDate weekEnd) {
+        boolean already = challengeRepository.existsByUserAndStartDateGreaterThanEqualAndEndDateLessThanEqual(
+                user, weekStart, weekEnd
+        );
+        if (already) {
+            return challengeRepository.findAllByUserAndStartDateGreaterThanEqualAndEndDateLessThanEqual(
+                    user, weekStart, weekEnd
+            );
+        }
+
+        List<Challenges> created = fromLLMOrFallback(user, weekStart, weekEnd);
+        return challengeRepository.saveAll(created);
+    }
+
+    private List<Challenges> fromLLMOrFallback(User user, LocalDate weekStart, LocalDate weekEnd) {
+        try {
+            String prompt = """
+                너는 '일주일 건강 챌린지' 코치야.
+                사용자에게 줄 '음식 기반 챌린지' 3개를 JSON으로만 응답해.
+                {
+                  "challenges": [
+                    { "title": "커피 마시기", "targetMenu": "커피", "description": "오늘은 아메리카노 한 잔!" },
+                    { "title": "그릭요거트 먹기", "targetMenu": "그릭요거트", "description": "단백질+유산균 보충" },
+                    { "title": "사과 먹기", "targetMenu": "사과", "description": "식이섬유 챙기기" }
+                  ]
+                }
+                - targetMenu는 Meals.menu에 포함 매칭 가능한 키워드여야 함.
+                """;
+
+            String raw = openAiClient.requestCompletion("당신은 건강 관리 전문가입니다.", prompt);
+            // 코드블록 마커 제거 등 간단 전처리
+            String cleaned = raw.replaceAll("(?s)```json|```", "").trim();
+
+            ChallengeAiResponse parsed = objectMapper.readValue(cleaned, ChallengeAiResponse.class);
+
+            List<Challenges> list = new ArrayList<>();
+            if (parsed.getChallenges() != null) {
+                parsed.getChallenges().stream().limit(3).forEach(it ->
+                        list.add(Challenges.builder()
+                                .user(user)
+                                .title(nvl(it.getTitle(), it.getTargetMenu() + " 먹기"))
+                                .targetMenuName(nvl(it.getTargetMenu(), "사과"))
+                                .description(nvl(it.getDescription(), "가볍게 도전!"))
+                                .startDate(weekStart)
+                                .endDate(weekEnd)
+                                .status(ChallengeStatus.PENDING)
+                                .build())
+                );
+            }
+
+            while (list.size() < 3) {
+                String m = FALLBACK_MENUS.get(list.size());
+                list.add(Challenges.builder()
+                        .user(user)
+                        .title(m + " 먹기")
+                        .targetMenuName(m)
+                        .description("가볍게 도전!")
+                        .startDate(weekStart)
+                        .endDate(weekEnd)
+                        .status(ChallengeStatus.PENDING)
+                        .build());
+            }
+            return list;
+
+        } catch (Exception e) {
+            log.warn("LLM 생성 실패. fallback 사용: {}", e.toString());
+            List<Challenges> list = new ArrayList<>();
+            Collections.shuffle(FALLBACK_MENUS);
+            for (int i = 0; i < 3; i++) {
+                String m = FALLBACK_MENUS.get(i);
+                list.add(Challenges.builder()
+                        .user(user)
+                        .title(m + " 먹기")
+                        .targetMenuName(m)
+                        .description("가볍게 도전!")
+                        .startDate(weekStart)
+                        .endDate(weekEnd)
+                        .status(ChallengeStatus.PENDING)
+                        .build());
+            }
+            return list;
+        }
+    }
+
+    private static String nvl(String s, String def) { return (s == null || s.isBlank()) ? def : s; }
+}

--- a/src/main/java/snapmeal/snapmeal/service/ChallengeScheduler.java
+++ b/src/main/java/snapmeal/snapmeal/service/ChallengeScheduler.java
@@ -1,0 +1,51 @@
+package snapmeal.snapmeal.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import snapmeal.snapmeal.domain.User;
+import snapmeal.snapmeal.repository.UserRepository;
+import snapmeal.snapmeal.service.ChallengeGeneratorService;
+import snapmeal.snapmeal.service.ChallengeService;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+/**
+ * 챌린지 스케줄러
+ * - 매일 00:10 (KST): 자정 성공/실패 판정
+ * - 매주 월요일 00:20 (KST): 이번 주 챌린지 3개 생성
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeScheduler {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final ChallengeService challengeService;
+    private final ChallengeGeneratorService generatorService;
+    private final UserRepository userRepository;
+
+    /** 자정 직후 평가: 어제까지 끝난 챌린지를 SUCCESS/FAIL로 마감 */
+    @Scheduled(cron = "0 10 0 * * *", zone = "Asia/Seoul")
+    public void evaluateDailyAtMidnight() {
+        challengeService.evaluateDaily();
+    }
+
+    /** 주간 챌린지 생성: 주가 바뀐 직후(월 00:20)에 생성 */
+    @Scheduled(cron = "0 20 0 * * MON", zone = "Asia/Seoul")
+    public void generateWeeklyChallenges() {
+        LocalDate today = LocalDate.now(KST);
+        LocalDate weekStart = today.with(DayOfWeek.MONDAY);
+        LocalDate weekEnd = weekStart.plusDays(6);
+
+        List<User> users = userRepository.findAll();
+        for (User u : users) {
+            generatorService.generateWeeklyForUser(u, weekStart, weekEnd);
+        }
+    }
+}

--- a/src/main/java/snapmeal/snapmeal/service/ChallengeService.java
+++ b/src/main/java/snapmeal/snapmeal/service/ChallengeService.java
@@ -1,0 +1,144 @@
+package snapmeal.snapmeal.service;
+
+import com.amazonaws.services.kms.model.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import snapmeal.snapmeal.domain.ChallengeReviews;
+import snapmeal.snapmeal.domain.Challenges;
+import snapmeal.snapmeal.domain.User;
+import snapmeal.snapmeal.domain.enums.ChallengeStatus;
+import snapmeal.snapmeal.global.util.AuthService;
+import snapmeal.snapmeal.repository.ChallengeRepository;
+import snapmeal.snapmeal.repository.ChallengeReviewRepository;
+import snapmeal.snapmeal.repository.MealsRepository;
+import snapmeal.snapmeal.web.dto.ChallengeDto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChallengeService {
+
+    private final ChallengeRepository challengeRepository;
+    private final ChallengeReviewRepository reviewRepository;
+    private final MealsRepository mealsRepository;
+    private final AuthService authService;
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Transactional
+    public ChallengeDto.ParticipateResponse participate(Long challengeId) {
+        User user = authService.getCurrentUser();
+        Challenges c = challengeRepository.findByChallengeIdAndUser(challengeId, user)
+                .orElseThrow(() -> new NotFoundException("챌린지를 찾을 수 없습니다."));
+        c.participate();
+        return new ChallengeDto.ParticipateResponse(c.getStatus().name());
+    }
+
+    @Transactional
+    public ChallengeDto.ParticipateResponse giveUp(Long challengeId) {
+        User user = authService.getCurrentUser();
+        Challenges c = challengeRepository.findByChallengeIdAndUser(challengeId, user)
+                .orElseThrow(() -> new NotFoundException("챌린지를 찾을 수 없습니다."));
+        c.giveUp();
+        return new ChallengeDto.ParticipateResponse(c.getStatus().name());
+    }
+
+    @Transactional(readOnly = true)
+    public List<Challenges> listMine(String statusesCsv) {
+        User user = authService.getCurrentUser();
+        List<ChallengeStatus> statuses = Arrays.stream(statusesCsv.split(","))
+                .map(String::trim)
+                .map(ChallengeStatus::valueOf)
+                .toList();
+        return challengeRepository.findAllByUserAndStatusIn(user, statuses);
+    }
+
+    /** 매일 00:10에 어제까지 종료된 챌린지를 SUCCESS/FAIL로 판정 */
+    @Transactional
+    public void evaluateDaily() {
+        LocalDate today = LocalDate.now(KST);
+        List<Challenges> targets = challengeRepository.findAllByStatusInAndEndDateLessThanEqual(
+                List.of(ChallengeStatus.PENDING, ChallengeStatus.IN_PROGRESS),
+                today.minusDays(1)
+        );
+
+        for (Challenges c : targets) {
+            LocalDateTime startDt = c.getStartDate().atStartOfDay();
+            LocalDateTime endDt = c.getEndDate().atTime(23, 59, 59);
+
+            boolean ok = mealsRepository.existsByUserAndMealDateBetweenAndMenuContainingIgnoreCase(
+                    c.getUser(), startDt, endDt, c.getTargetMenuName()
+            );
+            if (ok) c.success(LocalDateTime.now(KST));
+            else c.fail();
+        }
+    }
+
+    @Transactional
+    public ChallengeDto.ReviewResponse createReview(Long challengeId, ChallengeDto.ReviewCreateOrUpdateRequest req) {
+        if (req.getRating() == null || req.getRating() < 1 || req.getRating() > 5) {
+            throw new IllegalArgumentException("별점은 1~5 범위여야 합니다.");
+        }
+        User user = authService.getCurrentUser();
+        Challenges challenge = challengeRepository.findByChallengeIdAndUser(challengeId, user)
+                .orElseThrow(() -> new NotFoundException("챌린지를 찾을 수 없습니다."));
+
+        ChallengeReviews review = reviewRepository.save(
+                ChallengeReviews.builder()
+                        .challenge(challenge)
+                        .user(user)
+                        .rating(req.getRating())
+                        .content(req.getContent())
+                        .build()
+        );
+        return toReviewDto(review);
+    }
+
+    @Transactional
+    public ChallengeDto.ReviewResponse updateReview(Long reviewId, ChallengeDto.ReviewCreateOrUpdateRequest req) {
+        User user = authService.getCurrentUser();
+        ChallengeReviews review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new NotFoundException("후기를 찾을 수 없습니다."));
+        if (!review.getUser().getId().equals(user.getId())) {
+            throw new IllegalStateException("본인 후기만 수정할 수 있습니다.");
+        }
+        if (req.getRating() != null) {
+            if (req.getRating() < 1 || req.getRating() > 5) {
+                throw new IllegalArgumentException("별점은 1~5 범위여야 합니다.");
+            }
+            review.setRating(req.getRating());
+        }
+        review.setContent(req.getContent());
+        return toReviewDto(review);
+    }
+
+    @Transactional
+    public void deleteReview(Long reviewId) {
+        User user = authService.getCurrentUser();
+        ChallengeReviews review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new NotFoundException("후기를 찾을 수 없습니다."));
+        if (!review.getUser().getId().equals(user.getId())) {
+            throw new IllegalStateException("본인 후기만 삭제할 수 있습니다.");
+        }
+        reviewRepository.delete(review);
+    }
+
+    private ChallengeDto.ReviewResponse toReviewDto(ChallengeReviews r) {
+        ChallengeDto.ReviewResponse dto = new ChallengeDto.ReviewResponse();
+        dto.setReviewId(r.getReviewId());
+        dto.setChallengeId(r.getChallenge().getChallengeId());
+        dto.setRating(r.getRating());
+        dto.setContent(r.getContent());
+        dto.setCreatedAt(r.getCreatedAt());
+        dto.setUpdatedAt(r.getUpdatedAt());
+        return dto;
+    }
+}

--- a/src/main/java/snapmeal/snapmeal/web/controller/ChallengeController.java
+++ b/src/main/java/snapmeal/snapmeal/web/controller/ChallengeController.java
@@ -1,0 +1,77 @@
+package snapmeal.snapmeal.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import snapmeal.snapmeal.domain.Challenges;
+import snapmeal.snapmeal.global.util.AuthService;
+import snapmeal.snapmeal.service.ChallengeGeneratorService;
+import snapmeal.snapmeal.service.ChallengeService;
+import snapmeal.snapmeal.web.dto.ChallengeDto;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/challenges")
+@RequiredArgsConstructor
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+    private final ChallengeGeneratorService generatorService;
+    private final AuthService authService;
+
+    @Operation(summary = "내 챌린지 목록 조회")
+    @GetMapping("/my")
+    public List<ChallengeDto.Response> listMine(
+            @RequestParam(required = false, defaultValue = "IN_PROGRESS,SUCCESS,PENDING") String statuses
+    ) {
+        return challengeService.listMine(statuses).stream().map(this::toDto).toList();
+    }
+
+    @Operation(summary = "챌린지 참여하기")
+    @ApiResponse(responseCode = "200", content = @Content(
+            mediaType = "application/json",
+            examples = @ExampleObject(value = "{ \"status\": \"IN_PROGRESS\" }"),
+            schema = @Schema(implementation = ChallengeDto.ParticipateResponse.class)
+    ))
+    @PostMapping("/{challengeId}/participate")
+    public ChallengeDto.ParticipateResponse participate(@PathVariable Long challengeId) {
+        return challengeService.participate(challengeId);
+    }
+
+    @Operation(summary = "챌린지 포기하기")
+    @PostMapping("/{challengeId}/give-up")
+    public ChallengeDto.ParticipateResponse giveUp(@PathVariable Long challengeId) {
+        return challengeService.giveUp(challengeId);
+    }
+
+    // (테스트용) 이번 주 3개 생성 — 현재 로그인 사용자 기준
+    @PostMapping("/weekly/generate")
+    public List<ChallengeDto.Response> generateWeeklyForMe() {
+        var user = authService.getCurrentUser();
+        LocalDate today = LocalDate.now();
+        LocalDate weekStart = today.with(DayOfWeek.MONDAY);
+        LocalDate weekEnd = weekStart.plusDays(6);
+        return generatorService.generateWeeklyForUser(user, weekStart, weekEnd)
+                .stream().map(this::toDto).toList();
+    }
+
+    private ChallengeDto.Response toDto(Challenges c) {
+        return ChallengeDto.Response.builder()
+                .challengeId(c.getChallengeId())
+                .title(c.getTitle())
+                .targetMenuName(c.getTargetMenuName())
+                .description(c.getDescription())
+                .startDate(c.getStartDate())
+                .endDate(c.getEndDate())
+                .status(c.getStatus().name())
+                .participatedAt(c.getParticipatedAt())
+                .completedAt(c.getCompletedAt())
+                .cancelledAt(c.getCancelledAt())
+                .build();
+    }
+}

--- a/src/main/java/snapmeal/snapmeal/web/dto/ChallengeAiResponse.java
+++ b/src/main/java/snapmeal/snapmeal/web/dto/ChallengeAiResponse.java
@@ -1,0 +1,20 @@
+package snapmeal.snapmeal.web.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+// OpenAI가 반환하는 JSON을 Jackson으로 바로 매핑하기 위한 DTO
+@Getter @Setter @NoArgsConstructor
+public class ChallengeAiResponse {
+    private List<Item> challenges;
+
+    @Getter @Setter @NoArgsConstructor
+    public static class Item {
+        private String title;       // 예: "커피 마시기"
+        private String targetMenu;  // 예: "커피"
+        private String description; // 예: "오늘은 아메리카노 한 잔!"
+    }
+}

--- a/src/main/java/snapmeal/snapmeal/web/dto/ChallengeDto.java
+++ b/src/main/java/snapmeal/snapmeal/web/dto/ChallengeDto.java
@@ -1,0 +1,68 @@
+package snapmeal.snapmeal.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class ChallengeDto {
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Response {
+        @Schema(example = "1")
+        private Long challengeId; // 엔티티 PK와 매핑
+
+        @Schema(example = "커피 마시기")
+        private String title;
+
+        @Schema(example = "커피")
+        private String targetMenuName;
+
+        @Schema(example = "오늘은 아메리카노 한 잔!")
+        private String description;
+
+        @Schema(example = "2025-09-01")
+        private LocalDate startDate;
+
+        @Schema(example = "2025-09-07")
+        private LocalDate endDate;
+
+        @Schema(example = "IN_PROGRESS")
+        private String status;
+
+        private LocalDateTime participatedAt;
+        private LocalDateTime completedAt;
+        private LocalDateTime cancelledAt;
+    }
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class ParticipateResponse {
+        @Schema(example = "\"IN_PROGRESS\"")
+        private String status;
+    }
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class ReviewCreateOrUpdateRequest {
+        @Schema(example = "5")
+        private Integer rating;  // 1~5
+
+        @Schema(example = "재밌었다~!")
+        private String content;
+    }
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class ReviewResponse {
+        private Long reviewId;
+        private Long challengeId;
+
+        @Schema(example = "5")
+        private Integer rating;
+
+        @Schema(example = "다음에 또 해야지!")
+        private String content;
+
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #20 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. 챌린지 생성 (주 3개) / challenges/weekly/generate 
<img width="2316" height="1620" alt="image" src="https://github.com/user-attachments/assets/7edb8fa4-fd3e-4fad-a0ab-46b4fb553603" />

2. 챌린지 참여하기 /challenges/{challengeId}/participate
<img width="2310" height="1664" alt="image" src="https://github.com/user-attachments/assets/d8e2cd65-d494-465c-8a7f-dc3d3d0b60d8" />

3. 챌린지 참여 목록 조회 /challenges/my
<img width="2310" height="1664" alt="image" src="https://github.com/user-attachments/assets/66f93192-a942-4e2e-a330-8c5ced74976c" />

4. 챌린지 포기하기 /challenges/{challengeId}/give-up
<img width="2324" height="1684" alt="image" src="https://github.com/user-attachments/assets/7bd6a3d1-8e84-4820-9d0f-afc9f1cd7d1c" />

