### PR TITLE
[Refactor][jjaeroong]: 날짜별 식사 기록 조회 API 및 오늘 영양소 합계 조휘 API 구현

### DIFF
--- a/src/main/java/snapmeal/snapmeal/converter/MealsConverter.java
+++ b/src/main/java/snapmeal/snapmeal/converter/MealsConverter.java
@@ -1,32 +1,15 @@
-package snapmeal.snapmeal.web.dto;
+package snapmeal.snapmeal.converter;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
+import org.springframework.stereotype.Component;
 import snapmeal.snapmeal.domain.Meals;
-import snapmeal.snapmeal.domain.enums.MealType;
+import snapmeal.snapmeal.web.dto.MealsResponseDto;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
-@Data
-@Getter
-@Builder
-public class MealsResponseDto {
-    private Long mealId;
-    private MealType mealType;
-    private String memo;
-    private String location;
-    private LocalDateTime mealDate;
-    private double calories;
-    private double protein;
-    private double carbs;
-    private double sugar;
-    private double fat;
+@Component
+public class MealsConverter {
 
-    private String className;
-    private String imageUrl;
-
-    public static MealsResponseDto from(Meals meal) {
+    public MealsResponseDto toDto(Meals meal) {
         return MealsResponseDto.builder()
                 .mealId(meal.getMealId())
                 .mealType(meal.getMealType())
@@ -41,5 +24,11 @@ public class MealsResponseDto {
                 .className(meal.getImage().getClassName())
                 .imageUrl(meal.getImage().getImageUrl())
                 .build();
+    }
+
+    public List<MealsResponseDto> toDtoList(List<Meals> meals) {
+        return meals.stream()
+                .map(this::toDto)
+                .toList();
     }
 }

--- a/src/main/java/snapmeal/snapmeal/converter/NutritionConverter.java
+++ b/src/main/java/snapmeal/snapmeal/converter/NutritionConverter.java
@@ -3,8 +3,12 @@ package snapmeal.snapmeal.converter;
 import org.json.JSONArray;
 
 import org.json.JSONObject;
+import org.springframework.stereotype.Component;
 import snapmeal.snapmeal.web.dto.NutritionRequestDto;
+import snapmeal.snapmeal.web.dto.TodayNutritionResponseDto;
 
+import java.time.LocalDate;
+@Component
 public class NutritionConverter {
     public static NutritionRequestDto.TotalNutritionRequestDto fromOpenAiJson(String jsonResponse){
         JSONArray array = new JSONArray(jsonResponse);
@@ -21,6 +25,23 @@ public class NutritionConverter {
         }
 
         return new NutritionRequestDto.TotalNutritionRequestDto(totalCalories, totalProtein, totalCarbs, totalSugar, totalFat, null);
+    }
+    public TodayNutritionResponseDto toSummaryDto(
+            LocalDate date,
+            int totalCalories,
+            double totalProtein,
+            double totalCarbs,
+            double totalSugar,
+            double totalFat
+    ) {
+        return TodayNutritionResponseDto.builder()
+                .date(date)
+                .totalCalories(totalCalories)
+                .totalProtein(totalProtein)
+                .totalCarbs(totalCarbs)
+                .totalSugar(totalSugar)
+                .totalFat(totalFat)
+                .build();
     }
 
 }

--- a/src/main/java/snapmeal/snapmeal/converter/WeeklyReportConverter.java
+++ b/src/main/java/snapmeal/snapmeal/converter/WeeklyReportConverter.java
@@ -1,0 +1,47 @@
+package snapmeal.snapmeal.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import snapmeal.snapmeal.domain.WeeklyReports;
+import snapmeal.snapmeal.web.dto.WeeklyReportAiResponse;
+import snapmeal.snapmeal.web.dto.WeeklyReportResponseDto;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WeeklyReportConverter {
+
+    private final ObjectMapper objectMapper;
+
+    public WeeklyReportResponseDto toDto(WeeklyReports report) {
+        try {
+            // String(JSON) → 객체 변환
+            WeeklyReportAiResponse.CaloriePattern caloriePattern =
+                    objectMapper.readValue(report.getCaloriePattern(), WeeklyReportAiResponse.CaloriePattern.class);
+
+            List<WeeklyReportAiResponse.GuideItem> healthGuidance =
+                    objectMapper.readValue(
+                            report.getHealthGuidance(),
+                            objectMapper.getTypeFactory().constructCollectionType(List.class, WeeklyReportAiResponse.GuideItem.class)
+                    );
+
+            // Builder로 DTO 생성
+            return WeeklyReportResponseDto.builder()
+                    .reportDate(report.getReportDate())
+                    .totalCalories(report.getTotalCalories())
+                    .totalProtein(report.getTotalProtein())
+                    .totalFat(report.getTotalFat())
+                    .totalCarbs(report.getTotalCarbs())
+                    .nutritionSummary(report.getNutritionSummary())
+                    .caloriePattern(caloriePattern)
+                    .healthGuidance(healthGuidance)
+                    .build();
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("리포트 JSON 파싱 실패", e);
+        }
+    }
+}

--- a/src/main/java/snapmeal/snapmeal/global/code/ErrorCode.java
+++ b/src/main/java/snapmeal/snapmeal/global/code/ErrorCode.java
@@ -29,9 +29,11 @@ public enum ErrorCode implements BaseErrorCode {
     NOT_AUTHORIZED_TO_CHANGE_REQUEST(HttpStatus.FORBIDDEN, "MATE003", "요청을 변경할 권한이 없습니다."),
     UNAUTHORIZED_ACTION(HttpStatus.FORBIDDEN, "MATE002", "해당 요청에 대한 권한이 없습니다."),
     ALREADY_PROCESSED_REQUEST(HttpStatus.BAD_REQUEST, "MATE003", "이미 처리된 친구 요청입니다."),
-    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "MATE003", "해당 친구 요청이 존재하지 않습니다.");
+    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "MATE003", "해당 친구 요청이 존재하지 않습니다."),
 
-
+    //weekly report 관련 응답
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT001", "주간 리포트를 찾을 수 없습니다."),
+    AI_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI001", "AI 응답 처리 중 오류가 발생했습니다.");
     private final HttpStatus httpStatus;
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/snapmeal/snapmeal/global/handler/ReportHandler.java
+++ b/src/main/java/snapmeal/snapmeal/global/handler/ReportHandler.java
@@ -1,0 +1,10 @@
+package snapmeal.snapmeal.global.handler;
+
+import snapmeal.snapmeal.global.GeneralException;
+import snapmeal.snapmeal.global.code.BaseErrorCode;
+
+public class ReportHandler extends GeneralException {
+    public ReportHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/snapmeal/snapmeal/global/util/OpenAiConverter.java
+++ b/src/main/java/snapmeal/snapmeal/global/util/OpenAiConverter.java
@@ -1,4 +1,4 @@
-package snapmeal.snapmeal.converter;
+package snapmeal.snapmeal.global.util;
 
 import java.util.List;
 

--- a/src/main/java/snapmeal/snapmeal/global/util/WeeklyReportPromptBuilder.java
+++ b/src/main/java/snapmeal/snapmeal/global/util/WeeklyReportPromptBuilder.java
@@ -1,0 +1,44 @@
+package snapmeal.snapmeal.global.util;
+
+import org.springframework.stereotype.Component;
+import snapmeal.snapmeal.domain.NutritionAnalysis;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class WeeklyReportPromptBuilder {
+
+    public String buildWeeklyReportPrompt(List<NutritionAnalysis> list, float totalCal, float totalCarb) {
+        return String.format("""
+            아래는 사용자의 일주일간 식단 정보입니다.
+            총 칼로리: %.1f kcal, 총 탄수화물: %.1f g
+            하루별 섭취 기록:
+            %s
+
+            아래 세 항목을 각각 문단으로 설명하고 JSON으로 응답해주세요:
+            1. 영양소 섭취 경향 요약 (짧은 설명 2줄)
+            2. 저녁 시간대 위주의 섭취 경향 및 수치 요약 (대표 이모지 1개 + 요약 3개)
+            3. 식사 및 생활 가이드 (번호 + 소제목 + 짧은 설명, 총 2개)
+
+            응답 예시:
+            {
+              "nutritionSummary": "...",
+              "caloriePattern": {
+                "emoji": "🌙",
+                "summaries": ["...", "...", "..."]
+              },
+              "healthGuidance": [
+                { "title": "영양 균형 잡기", "description": "..." },
+                { "title": "저녁·야식은 가볍게", "description": "..." }
+              ]
+            }
+            """,
+                totalCal, totalCarb,
+                list.stream()
+                        .map(n -> "- " + n.getFoodNames() + ": " + n.getCalories() + "kcal")
+                        .collect(Collectors.joining("\n"))
+        );
+    }
+}
+

--- a/src/main/java/snapmeal/snapmeal/repository/MealsRepository.java
+++ b/src/main/java/snapmeal/snapmeal/repository/MealsRepository.java
@@ -6,6 +6,7 @@ import snapmeal.snapmeal.domain.Meals;
 import snapmeal.snapmeal.domain.User;
 import snapmeal.snapmeal.domain.enums.MealType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MealsRepository extends JpaRepository<Meals, Long> {
@@ -17,4 +18,6 @@ public interface MealsRepository extends JpaRepository<Meals, Long> {
             java.time.LocalDateTime endInclusive,
             String targetKeyword
     );
+    List<Meals> findAllByUserAndCreatedAtBetween(User user, LocalDateTime start, LocalDateTime end);
+
 }

--- a/src/main/java/snapmeal/snapmeal/service/DietTypeService.java
+++ b/src/main/java/snapmeal/snapmeal/service/DietTypeService.java
@@ -4,7 +4,7 @@ package snapmeal.snapmeal.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import snapmeal.snapmeal.converter.OpenAiConverter;
+import snapmeal.snapmeal.global.util.OpenAiConverter;
 import snapmeal.snapmeal.global.OpenAiClient;
 import snapmeal.snapmeal.web.dto.DietTypeRequestDto;
 import snapmeal.snapmeal.web.dto.DietTypeResponseDto;

--- a/src/main/java/snapmeal/snapmeal/service/FoodNutritionCommandService.java
+++ b/src/main/java/snapmeal/snapmeal/service/FoodNutritionCommandService.java
@@ -11,7 +11,7 @@ import snapmeal.snapmeal.global.OpenAiClient;
 import snapmeal.snapmeal.repository.ImageRepository;
 import snapmeal.snapmeal.repository.NutritionAnalysisRepository;
 import snapmeal.snapmeal.web.dto.NutritionRequestDto;
-import snapmeal.snapmeal.converter.OpenAiConverter;
+import snapmeal.snapmeal.global.util.OpenAiConverter;
 import snapmeal.snapmeal.global.util.AuthService;
 
 @Service

--- a/src/main/java/snapmeal/snapmeal/service/FoodNutritionService.java
+++ b/src/main/java/snapmeal/snapmeal/service/FoodNutritionService.java
@@ -13,14 +13,21 @@ import snapmeal.snapmeal.repository.NutritionAnalysisRepository;
 import snapmeal.snapmeal.web.dto.NutritionRequestDto;
 import snapmeal.snapmeal.global.util.OpenAiConverter;
 import snapmeal.snapmeal.global.util.AuthService;
+import snapmeal.snapmeal.web.dto.TodayNutritionResponseDto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class FoodNutritionCommandService {
+public class FoodNutritionService {
     private final OpenAiClient openAiClient;
     private final ImageRepository imagesRepository;
     private final AuthService authService;
     private final NutritionAnalysisRepository nutritionAnalysisRepository;
+    private final NutritionConverter nutritionConverter;
 
     @Transactional
     public NutritionRequestDto.TotalNutritionRequestDto analyze(NutritionRequestDto.FoodNutritionRequestDto request) {
@@ -55,4 +62,32 @@ public class FoodNutritionCommandService {
             return new NutritionRequestDto.TotalNutritionRequestDto(0, 0, 0, 0, 0, 0L);
         }
     }
+    @Transactional(readOnly = true)
+    public TodayNutritionResponseDto getTodaySummary() {
+        User user = authService.getCurrentUser();
+
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+        List<NutritionAnalysis> analyses =
+                nutritionAnalysisRepository.findAllByUserAndCreatedAtBetween(user, startOfDay, endOfDay);
+
+        int totalCalories = 0;
+        double totalProtein = 0;
+        double totalCarbs = 0;
+        double totalSugar = 0;
+        double totalFat = 0;
+
+        for (NutritionAnalysis na : analyses) {
+            totalCalories += na.getCalories();
+            totalProtein += na.getProtein();
+            totalCarbs += na.getCarbs();
+            totalSugar += na.getSugar();
+            totalFat += na.getFat();
+        }
+
+        return nutritionConverter.toSummaryDto(today, totalCalories, totalProtein, totalCarbs, totalSugar, totalFat);
+    }
+
 }

--- a/src/main/java/snapmeal/snapmeal/service/WeeklyReportService.java
+++ b/src/main/java/snapmeal/snapmeal/service/WeeklyReportService.java
@@ -7,11 +7,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import snapmeal.snapmeal.converter.WeeklyReportConverter;
 import snapmeal.snapmeal.domain.NutritionAnalysis;
 import snapmeal.snapmeal.domain.WeeklyReportDetails;
 import snapmeal.snapmeal.domain.WeeklyReports;
 import snapmeal.snapmeal.global.OpenAiClient;
+import snapmeal.snapmeal.global.code.ErrorCode;
+import snapmeal.snapmeal.global.handler.ReportHandler;
+import snapmeal.snapmeal.global.handler.UserHandler;
 import snapmeal.snapmeal.global.util.AuthService;
+import snapmeal.snapmeal.global.util.WeeklyReportPromptBuilder;
 import snapmeal.snapmeal.repository.NutritionAnalysisRepository;
 import snapmeal.snapmeal.repository.UserRepository;
 import snapmeal.snapmeal.repository.WeeklyReportRepository;
@@ -37,6 +42,9 @@ public class WeeklyReportService {
     private final OpenAiClient openAiClient;
     private final UserRepository userRepository;
     private final AuthService authService;
+    private final WeeklyReportPromptBuilder promptBuilder;
+    private final ObjectMapper objectMapper;
+    private final WeeklyReportConverter weeklyReportConverter;
 
     @Transactional
     public void generateWeeklyReports() {
@@ -44,14 +52,14 @@ public class WeeklyReportService {
 
         for (User user : users) {
             try {
-//                LocalDate today = LocalDate.now();
+                //                LocalDate today = LocalDate.now();
 //                LocalDate weekStart = today.with(DayOfWeek.MONDAY);
 //                LocalDate weekEnd = today.with(DayOfWeek.SUNDAY);
-
-                LocalDate weekStart = LocalDate.of(2025, 7, 14);
+                LocalDate weekStart = LocalDate.of(2025, 9, 15); // TODO: 운영 시 LocalDate.now().with(DayOfWeek.MONDAY)
                 LocalDate weekEnd = LocalDate.now();
-                List<NutritionAnalysis> analyses = nutritionAnalysisRepository
-                        .findAllByUserAndCreatedAtBetween(
+
+                List<NutritionAnalysis> analyses =
+                        nutritionAnalysisRepository.findAllByUserAndCreatedAtBetween(
                                 user,
                                 weekStart.atStartOfDay(),
                                 weekEnd.atTime(LocalTime.MAX)
@@ -59,6 +67,7 @@ public class WeeklyReportService {
 
                 if (analyses.isEmpty()) continue;
 
+                // 총합 계산
                 float totalCal = 0, totalProtein = 0, totalFat = 0, totalCarb = 0;
                 for (NutritionAnalysis na : analyses) {
                     totalCal += na.getCalories();
@@ -67,9 +76,17 @@ public class WeeklyReportService {
                     totalCarb += na.getCarbs();
                 }
 
-                String prompt = generateAiPrompt(analyses, totalCal, totalCarb);
+                // AI 호출
+                String prompt = promptBuilder.buildWeeklyReportPrompt(analyses, totalCal, totalCarb);
                 String aiResponse = openAiClient.requestCompletion("당신은 건강 관리 전문가입니다.", prompt);
-                WeeklyReportAiResponse parsed = parseAiResponse(aiResponse);
+
+                // 응답 파싱
+                WeeklyReportAiResponse parsed = objectMapper.readValue(aiResponse, WeeklyReportAiResponse.class);
+
+                // JSON 직렬화
+                String caloriePatternJson = objectMapper.writeValueAsString(parsed.getCaloriePattern());
+                String healthGuidanceJson = objectMapper.writeValueAsString(parsed.getHealthGuidance());
+
 
                 WeeklyReports report = WeeklyReports.builder()
                         .user(user)
@@ -79,67 +96,34 @@ public class WeeklyReportService {
                         .totalFat(totalFat)
                         .totalCarbs(totalCarb)
                         .nutritionSummary(parsed.getNutritionSummary())
-                        .caloriePattern(parsed.getCaloriePattern())
-                        .healthGuidance(parsed.getHealthGuidance())
+                        .caloriePattern(caloriePatternJson)
+                        .healthGuidance(healthGuidanceJson)
                         .build();
 
                 weeklyReportRepository.save(report);
 
-            } catch (IOException e) {
-                log.error("OpenAI 호출 실패 - 사용자: {}", user.getEmail(), e);
-                // 사용자별로 실패해도 다른 사용자 리포트는 계속 생성되게 처리
+            } catch (Exception e) {
+                log.error("OpenAI 리포트 생성 실패 - 사용자: {}", user.getEmail(), e);
+                throw new ReportHandler(ErrorCode.AI_RESPONSE_ERROR);
             }
+
         }
     }
-
-    private String generateAiPrompt(List<NutritionAnalysis> list, float totalCal, float totalCarb) {
-        return String.format("""
-            아래는 사용자의 일주일간 식단 정보입니다.
-            총 칼로리: %.1f kcal, 총 탄수화물: %.1f g
-            하루별 섭취 기록:
-            %s
-
-            아래 세 항목을 각각 문단으로 설명하고 JSON으로 응답해주세요:
-            1. 영양소 섭취 경향 요약
-            2. 저녁 시간대 위주의 섭취 경향 및 수치 요약
-            3. 식사 및 생활 가이드
-
-            응답 예시:
-            {
-              "nutritionSummary": "...",
-              "caloriePattern": "...",
-              "healthGuidance": "..."
-            }
-            """,
-                totalCal, totalCarb,
-                list.stream()
-                        .map(n -> "- " + n.getFoodNames() + ": " + n.getCalories() + "kcal")
-                        .collect(Collectors.joining("\n"))
-        );
-    }
-
-    private WeeklyReportAiResponse parseAiResponse(String json) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(json, WeeklyReportAiResponse.class);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("AI 응답 파싱 실패", e);
-        }
-    }
-
-
-
-
     @Transactional(readOnly = true)
-    public WeeklyReportResponseDto getMyWeeklyReport() {
+    public WeeklyReportResponseDto getWeeklyReportByWeekStart(LocalDate weekStart) {
         User user = authService.getCurrentUser();
 
-        LocalDate weekStart = LocalDate.now().with(DayOfWeek.MONDAY);
+        //weekStart가 null이면 저번 주 월요일로 기본값 설정
+        if (weekStart == null) {
+            weekStart = LocalDate.now().minusWeeks(1).with(DayOfWeek.MONDAY);
+        }
+
         WeeklyReports report = weeklyReportRepository
                 .findByUserAndReportDate(user, weekStart)
-                .orElseThrow(() -> new NotFoundException("이번 주 리포트가 아직 생성되지 않았습니다."));
+                .orElseThrow(() -> new ReportHandler(ErrorCode.REPORT_NOT_FOUND));
 
-        return new WeeklyReportResponseDto(report);
+        return weeklyReportConverter.toDto(report);
     }
+
 
 }

--- a/src/main/java/snapmeal/snapmeal/web/controller/FoodNutritionController.java
+++ b/src/main/java/snapmeal/snapmeal/web/controller/FoodNutritionController.java
@@ -4,52 +4,66 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import snapmeal.snapmeal.global.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import snapmeal.snapmeal.service.FoodNutritionCommandService;
-import snapmeal.snapmeal.service.WeeklyReportService;
+import snapmeal.snapmeal.global.code.ErrorCode;
+import snapmeal.snapmeal.global.swagger.ApiErrorCodeExamples;
+import snapmeal.snapmeal.service.FoodNutritionService;
 import snapmeal.snapmeal.web.dto.NutritionRequestDto;
-import snapmeal.snapmeal.web.dto.WeeklyReportResponseDto;
+import snapmeal.snapmeal.web.dto.TodayNutritionResponseDto;
 
 @RestController
 @RequestMapping("/nutritions")
 @RequiredArgsConstructor
 public class FoodNutritionController {
 
-    private final FoodNutritionCommandService foodNutritionCommandService;
+    private final FoodNutritionService foodNutritionService;
+
     @Operation(
             summary = "음식 영양 분석 요청",
             description = """
-        사용자가 선택한 음식 목록을 기반으로 OpenAI를 통해 칼로리, 단백질, 탄수화물, 당, 지방을 분석합니다.  
-        분석된 데이터는 DB에 저장되며, 응답으로 총합 영양성분 정보를 반환합니다.
-        """
+                사용자가 선택한 음식 목록을 기반으로 OpenAI를 통해 칼로리, 단백질, 탄수화물, 당, 지방을 분석합니다.  
+                분석된 데이터는 DB에 저장되며, 응답으로 총합 영양성분 정보를 반환합니다.
+                """
     )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "영양 분석 성공", content = @Content(schema = @Schema(implementation = NutritionRequestDto.TotalNutritionRequestDto.class))),
-            @ApiResponse(responseCode = "400", description = "요청 형식 오류"),
-            @ApiResponse(responseCode = "404", description = "이미지 ID에 해당하는 이미지 없음"),
-            @ApiResponse(responseCode = "500", description = "서버 오류 또는 OpenAI 응답 문제")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "201",
+            description = "식사 기록 생성 성공",
+            content = @Content(schema = @Schema(implementation = ApiResponse.class)) // ✅ ApiResponse 그대로
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.BAD_REQUEST
     })
     @PostMapping("/analyze")
-    public ResponseEntity<NutritionRequestDto.TotalNutritionRequestDto> analyzeNutrition(
+    public ResponseEntity<ApiResponse<NutritionRequestDto.TotalNutritionRequestDto>> analyzeNutrition(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "음식 이름 목록과 분석할 이미지 ID",
                     required = true,
-                    content = @Content(schema = @Schema(implementation = NutritionRequestDto.FoodNutritionRequestDto.class),
-            examples = @ExampleObject(
-                    name = "기본 예시",
-            summary = "떡볶이와 오뎅의 영양 분석 요청",
-            value = "{\"foodNames\": [\"떡볶이\", \"오뎅\"], \"imageId\": 1}"
-                ))
+                    content = @Content(
+                            schema = @Schema(implementation = NutritionRequestDto.FoodNutritionRequestDto.class),
+                            examples = @ExampleObject(
+                                    name = "기본 예시",
+                                    summary = "떡볶이와 오뎅의 영양 분석 요청",
+                                    value = "{\"foodNames\": [\"떡볶이\", \"오뎅\"], \"imageId\": 1}"
+                            )
+                    )
             )
-            @RequestBody NutritionRequestDto.FoodNutritionRequestDto request) {
-        NutritionRequestDto.TotalNutritionRequestDto result = foodNutritionCommandService.analyze(request);
-        return ResponseEntity.ok(result);
+            @RequestBody NutritionRequestDto.FoodNutritionRequestDto request
+    ) {
+        NutritionRequestDto.TotalNutritionRequestDto result = foodNutritionService.analyze(request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
-
-
+    @GetMapping("/today")
+    @Operation(
+            summary = "오늘 영양 합계 조회",
+            description = "오늘 기록된 식단의 총 칼로리, 단백질, 탄수화물, 지방, 당류 합계를 반환합니다."
+    )
+    public ResponseEntity<ApiResponse<TodayNutritionResponseDto>> getTodayNutritionSummary() {
+        TodayNutritionResponseDto summary = foodNutritionService.getTodaySummary();
+        return ResponseEntity.ok(ApiResponse.onSuccess(summary));
+    }
 }

--- a/src/main/java/snapmeal/snapmeal/web/controller/MealsController.java
+++ b/src/main/java/snapmeal/snapmeal/web/controller/MealsController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +18,7 @@ import snapmeal.snapmeal.service.MealsService;
 import snapmeal.snapmeal.web.dto.MealsRequestDto;
 import snapmeal.snapmeal.web.dto.MealsResponseDto;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,25 +40,27 @@ public class MealsController {
             ErrorCode.BAD_REQUEST
     })
     public ResponseEntity<ApiResponse<MealsResponseDto>> createMeal(@RequestBody MealsRequestDto request) {
-        Meals created = mealsService.createMeal(request);
-        MealsResponseDto response = MealsResponseDto.from(created);
+        MealsResponseDto response = mealsService.createMeal(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.onSuccess(response));
     }
 
     @GetMapping
-    @Operation(summary = "식사 기록 전체 조회", description = "사용자의 모든 식사 기록을 조회합니다.")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "식사 기록 전체 조회 성공",
-            content = @Content(schema = @Schema(implementation = ApiResponse.class))
+    @Operation(
+            summary = "하루 식단 조회 API",
+            description = "사용자의 하루 식단 목록을 조회합니다. " +
+                    "쿼리 파라미터 date(yyyy-MM-dd)를 지정하지 않으면 오늘 날짜를 기준으로 조회합니다."
     )
-    public ResponseEntity<ApiResponse<List<MealsResponseDto>>> getAllMeals() {
-        List<Meals> meals = mealsService.getAllMeals();
-        List<MealsResponseDto> responseList = meals.stream()
-                .map(MealsResponseDto::from)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(ApiResponse.onSuccess(responseList));
+    @ApiErrorCodeExamples({
+            ErrorCode.USER_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<List<MealsResponseDto>>> getMealsByDate(
+            @RequestParam(value = "date", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        List<MealsResponseDto> response = mealsService.getMealsByDate(date);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
+
 
     @GetMapping("/{mealId}")
     @Operation(summary = "단일 식사 기록 조회", description = "특정 식사 기록을 조회합니다.")

--- a/src/main/java/snapmeal/snapmeal/web/controller/WeeklyReportController.java
+++ b/src/main/java/snapmeal/snapmeal/web/controller/WeeklyReportController.java
@@ -1,14 +1,19 @@
 package snapmeal.snapmeal.web.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import snapmeal.snapmeal.global.ApiResponse;
+import snapmeal.snapmeal.global.code.ErrorCode;
+import snapmeal.snapmeal.global.swagger.ApiErrorCodeExamples;
 import snapmeal.snapmeal.service.WeeklyReportService;
 import snapmeal.snapmeal.web.dto.WeeklyReportResponseDto;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,13 +24,31 @@ public class WeeklyReportController {
     private final WeeklyReportService weeklyReportService;
 
 
-    @GetMapping("/me")
-    public ResponseEntity<WeeklyReportResponseDto> getMyReport() {
-        WeeklyReportResponseDto response = weeklyReportService.getMyWeeklyReport();
-        return ResponseEntity.ok(response);
+    @GetMapping("/weekly")
+    @Operation(
+            summary = "주간 리포트 조회 API",
+            description = "사용자의 주차별 리포트를 조회합니다. " +
+                    "쿼리 파라미터 weekStart(월요일 날짜)를 지정하지 않으면 기본적으로 저번 주 리포트를 반환합니다."
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.REPORT_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<WeeklyReportResponseDto>> getWeeklyReportByWeekStart(
+            @Parameter(
+                    description = "조회할 주차의 시작일(월요일 기준). 예시: 2025-09-15",
+                    example = "2025-09-15"
+            )
+            @RequestParam(value = "weekStart", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart
+    ) {
+        WeeklyReportResponseDto responseDto = weeklyReportService.getWeeklyReportByWeekStart(weekStart);
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
 
-    // ✅ 테스트용 수동 리포트 생성 API (운영에서는 삭제해도 됨)
+
+
+    // 테스트용 수동 리포트 생성 API
     @PostMapping("/weekly/generate")
     public ResponseEntity<Void> generateManually()  {
         weeklyReportService.generateWeeklyReports(); // 스케줄러와 동일한 로직 호출

--- a/src/main/java/snapmeal/snapmeal/web/dto/TodayNutritionResponseDto.java
+++ b/src/main/java/snapmeal/snapmeal/web/dto/TodayNutritionResponseDto.java
@@ -1,0 +1,19 @@
+package snapmeal.snapmeal.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+public class TodayNutritionResponseDto {
+
+    private LocalDate date;
+    private int totalCalories;
+    private double totalProtein;
+    private double totalCarbs;
+    private double totalSugar;
+    private double totalFat;
+
+}

--- a/src/main/java/snapmeal/snapmeal/web/dto/WeeklyReportAiResponse.java
+++ b/src/main/java/snapmeal/snapmeal/web/dto/WeeklyReportAiResponse.java
@@ -1,14 +1,58 @@
 package snapmeal.snapmeal.web.dto;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+
+import java.util.List;
+
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "주간 리포트 AI 응답")
 public class WeeklyReportAiResponse {
-    private String nutritionSummary;
-    private String caloriePattern;
-    private String healthGuidance;
-}
 
+    @Schema(description = "영양소 섭취 경향 요약", example = "탄수화물 섭취 비율이 높고 단백질 섭취가 부족했습니다.")
+    private String nutritionSummary;
+
+    @Schema(description = "칼로리 섭취 패턴 (이모지 + 요약 3개)")
+    private CaloriePattern caloriePattern;
+
+    @ArraySchema(
+            arraySchema = @Schema(description = "식사 및 생활 가이드 (2개 추천)"),
+            schema = @Schema(implementation = GuideItem.class)
+    )
+    private List<GuideItem> healthGuidance;
+
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "칼로리 섭취 패턴")
+    public static class CaloriePattern {
+        @Schema(description = "대표 이모지", example = "🌙")
+        private String emoji;
+
+        @ArraySchema(
+                arraySchema = @Schema(description = "짧은 요약 3개"),
+                schema = @Schema(example = "저녁에 칼로리 집중")
+        )
+        private List<String> summaries;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "행동 가이드 항목")
+    public static class GuideItem {
+        @Schema(description = "제목", example = "1. 영양 균형 잡기")
+        private String title;
+
+        @Schema(description = "짧은 설명 줄글", example = "단백질과 비타민을 보충해 전체 영양 균형을 맞추세요.")
+        private String description;
+    }
+}

--- a/src/main/java/snapmeal/snapmeal/web/dto/WeeklyReportResponseDto.java
+++ b/src/main/java/snapmeal/snapmeal/web/dto/WeeklyReportResponseDto.java
@@ -1,10 +1,12 @@
 package snapmeal.snapmeal.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import snapmeal.snapmeal.domain.WeeklyReportDetails;
 import snapmeal.snapmeal.domain.WeeklyReports;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Setter
@@ -13,32 +15,30 @@ import java.time.LocalDate;
 @Builder
 public class WeeklyReportResponseDto {
 
+
+    @Schema(description = "리포트 주차 시작일(월요일)", example = "2025-07-14")
     private LocalDate reportDate;
+
+    @Schema(description = "총 섭취 칼로리(kcal)", example = "14320.5")
     private Float totalCalories;
+
+    @Schema(description = "총 섭취 단백질(g)", example = "480.2")
     private Float totalProtein;
+
+    @Schema(description = "총 섭취 지방(g)", example = "350.7")
     private Float totalFat;
+
+    @Schema(description = "총 섭취 탄수화물(g)", example = "1850.9")
     private Float totalCarbs;
 
-    private String recommendedExercise;
-    private String foodSuggestion;
-
+    @Schema(description = "영양소 섭취 요약", example = "이번 주는 단백질이 부족하고 탄수화물 섭취가 많았습니다.")
     private String nutritionSummary;
-    private String caloriePattern;
-    private String healthGuidance;
 
-    public WeeklyReportResponseDto(WeeklyReports report) {
-        this.reportDate = report.getReportDate();
-        this.totalCalories = report.getTotalCalories();
-        this.totalProtein = report.getTotalProtein();
-        this.totalFat = report.getTotalFat();
-        this.totalCarbs = report.getTotalCarbs();
+    @Schema(description = "칼로리 패턴 요약")
+    private WeeklyReportAiResponse.CaloriePattern caloriePattern;
 
-        this.recommendedExercise = report.getRecommendedExercise();
-        this.foodSuggestion = report.getFoodSuggestion();
+    @Schema(description = "식사 및 생활 가이드")
+    private List<WeeklyReportAiResponse.GuideItem> healthGuidance;
 
-        this.nutritionSummary = report.getNutritionSummary();
-        this.caloriePattern = report.getCaloriePattern();
-        this.healthGuidance = report.getHealthGuidance();
-    }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #22

## 📝작업 내용

> 날짜별 식사 기록 조회 API 및 오늘 영양소 합계 조휘 API 구현,  주간 리포트 조회 응답 방식 수정



### 스크린샷 (선택)
<img width="470" height="350" alt="image" src="https://github.com/user-attachments/assets/630e78c7-645f-4f5d-84b1-a88a9fd8ebf4" />
<img width="713" height="480" alt="image" src="https://github.com/user-attachments/assets/086708eb-0467-4cad-b9d8-c1dd820ec36d" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
