### PR TITLE
Feat: 챌린지 스탬프, 리뷰 작성 로직 추가 & 식사기록 전체조회

### DIFF
--- a/src/main/java/snapmeal/snapmeal/converter/ChallengeConverter.java
+++ b/src/main/java/snapmeal/snapmeal/converter/ChallengeConverter.java
@@ -1,0 +1,130 @@
+package snapmeal.snapmeal.converter;
+
+import org.springframework.stereotype.Component;
+import snapmeal.snapmeal.domain.Challenges;
+import snapmeal.snapmeal.domain.enums.ChallengeStatus;
+import snapmeal.snapmeal.web.dto.ChallengeDto;
+
+import java.time.LocalDateTime;
+
+@Component
+public class ChallengeConverter {
+   /**
+    * [리스트용] 가벼운 응답: 목록 카드 등에 사용
+    * - participation/introduction 같은 중첩 데이터는 제외
+    */
+   public static ChallengeDto.Response toListDto(Challenges c) {
+       return ChallengeDto.Response.builder()
+               .challengeId(c.getChallengeId())
+               .title(c.getTitle())
+               .coverImageUrl(resolveCoverImageUrl(c)) // 엔티티에 없으면 규칙으로 생성
+               .targetMenuName(c.getTargetMenuName())
+               .description(c.getDescription())
+               .status(c.getStatus().name())
+               .startDate(c.getStartDate())
+               .endDate(c.getEndDate())
+               // 리스트에서는 introduction/participation 생략(필요시 최소 정보만 넣어도 됨)
+               // ✅ 회피형 여부 노출
+               .isAvoidType(c.isAvoidType())
+               .build();
+   }
+    /**
+     * [상세용] 사진 구조 그대로 채우는 응답:
+     * - introduction (mainGoal, purpose, detailDescription, weeklyTarget, successCondition)
+     * - participation (isParticipating, participatedAt)
+     */
+    public static ChallengeDto.Response toDetailDto(Challenges c) {
+        // 참여 여부 정책: IN_PROGRESS면 참여 중(필요 시 정책 바꿔도 됨)
+        boolean isParticipating = c.getStatus() == ChallengeStatus.IN_PROGRESS;
+        LocalDateTime participatedAt = c.getParticipatedAt();
+
+        return ChallengeDto.Response.builder()
+                .challengeId(c.getChallengeId())
+                .title(c.getTitle())
+                .coverImageUrl(resolveCoverImageUrl(c))
+                .targetMenuName(c.getTargetMenuName())
+                .description(c.getDescription())
+                .status(c.getStatus().name())
+                .startDate(c.getStartDate())
+                .endDate(c.getEndDate())
+                // ✅ 회피형 여부
+                .isAvoidType(c.isAvoidType())
+                // 소개 섹션: 엔티티에 전용 칼럼이 없으면 규칙/상수로 보강
+                .introduction(ChallengeDto.Response.Introduction.builder()
+                        .mainGoal(buildMainGoal(c))                        // 예: "커피 안마시기" 또는 "사과 먹기"
+                        .purpose(buildPurpose(c))                          // ✅ 동적 목적
+                        .detailDescription(c.getDescription())             // 엔티티 설명 그대로
+                        .weeklyTarget(c.isAvoidType() ? "매일 금지 도전" : "기간 중 1일 이상 기록") // ✅ 정책 반영
+                        .successCondition(buildSuccessCondition(c))        // ✅ 동적 성공조건
+                        .build())
+                .participation(ChallengeDto.Response.ParticipationInfo.builder()
+                        .isParticipating(c.getStatus() == ChallengeStatus.IN_PROGRESS) // ✅ 필드명 변경 반영
+                        .participatedAt(c.getParticipatedAt())
+                        .build())
+
+                .build();
+    }
+    // 목록용 (필요한 정보만)
+    public static ChallengeDto.Response toDto(Challenges c) {
+        return ChallengeDto.Response.builder()
+                .challengeId(c.getChallengeId())
+                .title(c.getTitle())
+                .targetMenuName(c.getTargetMenuName())
+                .description(c.getDescription())
+                .startDate(c.getStartDate())
+                .endDate(c.getEndDate())
+                .status(c.getStatus().name())
+                .build();
+    }
+
+    // ────────────────────────── 헬퍼들 ──────────────────────────
+
+    /** coverImageUrl 우선순위: 엔티티 값 > 규칙 생성 */
+    private static String resolveCoverImageUrl(Challenges c) {
+        // 엔티티에 URL이 없으면 targetMenuName 기반으로 자동 생성
+        String key = (c.getTargetMenuName() == null)
+                ? "default"
+                : c.getTargetMenuName().trim().toLowerCase();
+
+        // 한글이면 CDN 규칙에 따라 변환 필요할 수도 있음(예: 커피 → coffee)
+        return "https://cdn.snapmeal.app/challenges/" + key + "-off.png";
+    }
+
+    /** 한글/공백 등을 CDN 경로용으로 간단히 슬러그화(필요시 더 견고한 변환 로직 적용) */
+    private static String slugify(String s) {
+        // 예시: 소문자 변환 + 공백/특수문자 -> 하이픈
+        return s.trim().toLowerCase()
+                .replaceAll("[\\s]+", "-")
+                .replaceAll("[^a-z0-9\\-]", ""); // 한글이면 CDN 규칙에 맞게 별도 매핑 필요
+    }
+
+    /** 타이틀에서 간단 규칙으로 mainGoal 생성 (엔티티 칼럼이 있으면 그거 쓰는 게 가장 좋음) */
+    private static String buildMainGoal(Challenges c) {
+        String title = c.getTitle() == null ? "" : c.getTitle();
+        if (title.endsWith(" 마시기")) {
+            return title.replace(" 마시기", " 안마시기");
+        }
+        return title; // 기본은 타이틀 재사용
+    }
+
+    private static String buildPurpose(Challenges c) {
+        // 설명이 들어있으면 그걸 목적처럼 노출
+        if (c.getDescription() != null && !c.getDescription().isBlank()) {
+            return c.getDescription();
+        }
+        return c.isAvoidType()
+                ? "섭취 빈도 줄이기 및 절제 습관 형성"
+                : "영양 보충 및 건강한 식습관 형성";
+    }
+
+    private static String buildSuccessCondition(Challenges c) {
+        long days = c.getEndDate().toEpochDay() - c.getStartDate().toEpochDay() + 1;
+        if (c.isAvoidType()) {
+            return String.format("기간(%d일) 동안 \"%s\" 미기록 시 성공", days, c.getTargetMenuName());
+        } else {
+            // 현재 로직: 섭취형은 기간 중 1일 이상 기록하면 성공
+            return String.format("기간(%d일) 동안 \"%s\" 기록 1일 이상 시 성공", days, c.getTargetMenuName());
+        }
+    }
+
+}

--- a/src/main/java/snapmeal/snapmeal/domain/Challenges.java
+++ b/src/main/java/snapmeal/snapmeal/domain/Challenges.java
@@ -63,6 +63,13 @@ public class Challenges extends BaseEntity {
     @Column(name = "cancelled_at")
     private java.time.LocalDateTime cancelledAt;
 
+    // ✅ 회피형(예: “커피 안마시기”) 여부
+    // true  = 회피형(그날 해당 메뉴가 없어야 충족)
+    // false = 섭취형(그날 해당 메뉴가 있으면 충족)
+    @Column(name = "is_avoid_type", nullable = false)
+    @Builder.Default
+    private boolean isAvoidType = false;
+
     // ====== 도메인 메서드: 상태 전환 로직(서비스에서 재사용) ======
 
     /** 사용자가 "참여하기" 버튼을 눌렀을 때 호출 */

--- a/src/main/java/snapmeal/snapmeal/global/GeneralException.java
+++ b/src/main/java/snapmeal/snapmeal/global/GeneralException.java
@@ -18,4 +18,10 @@ public class GeneralException extends RuntimeException {
     public ErrorResponseDto getErrorResponseHttpStatus() {
         return errorCode.getErrorResponseHttpStatus();
     }
+
+    // 상세 메시지를 받을 수 있는 생성자
+    public GeneralException(BaseErrorCode errorCode, String detailMessage) {
+        super(detailMessage);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/snapmeal/snapmeal/repository/ChallengeRepository.java
+++ b/src/main/java/snapmeal/snapmeal/repository/ChallengeRepository.java
@@ -20,4 +20,10 @@ public interface ChallengeRepository extends JpaRepository<Challenges, Long> {
     Optional<Challenges> findByChallengeIdAndUser(Long challengeId, User user);
 
     boolean existsByUserAndStartDateGreaterThanEqualAndEndDateLessThanEqual(User user, LocalDate start, LocalDate end);
+    // ChallengeRepository
+    void deleteAllByUserAndStartDateGreaterThanEqualAndEndDateLessThanEqual(
+            User user, LocalDate start, LocalDate end
+    );
+
+    List<Challenges> findAllByUserOrderByStartDateDesc(User user);
 }

--- a/src/main/java/snapmeal/snapmeal/repository/MealsRepository.java
+++ b/src/main/java/snapmeal/snapmeal/repository/MealsRepository.java
@@ -20,4 +20,5 @@ public interface MealsRepository extends JpaRepository<Meals, Long> {
     );
     List<Meals> findAllByUserAndCreatedAtBetween(User user, LocalDateTime start, LocalDateTime end);
 
+    List<Meals> findAllByUserOrderByMealDateDesc(User user);
 }

--- a/src/main/java/snapmeal/snapmeal/service/ChallengeScheduler.java
+++ b/src/main/java/snapmeal/snapmeal/service/ChallengeScheduler.java
@@ -45,7 +45,7 @@ public class ChallengeScheduler {
 
         List<User> users = userRepository.findAll();
         for (User u : users) {
-            generatorService.generateWeeklyForUser(u, weekStart, weekEnd);
+            generatorService.generateWeeklyForUser(u, weekStart, weekEnd, false);
         }
     }
 }

--- a/src/main/java/snapmeal/snapmeal/service/ChallengeService.java
+++ b/src/main/java/snapmeal/snapmeal/service/ChallengeService.java
@@ -1,10 +1,11 @@
 package snapmeal.snapmeal.service;
 
-import com.amazonaws.services.kms.model.NotFoundException;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import snapmeal.snapmeal.converter.ChallengeConverter;
 import snapmeal.snapmeal.domain.ChallengeReviews;
 import snapmeal.snapmeal.domain.Challenges;
 import snapmeal.snapmeal.domain.User;
@@ -18,7 +19,9 @@ import snapmeal.snapmeal.web.dto.ChallengeDto;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 @Slf4j
@@ -33,35 +36,194 @@ public class ChallengeService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
+    /* ==========================
+     * 스탬프/판정 유틸
+     * ========================== */
+
+    // (임시) 회피형 여부. 엔티티 컬럼 도입 전까지 사용.
+    private boolean isAvoidType(Challenges c) {
+        String t = (c.getTitle() + " " + c.getDescription()).toLowerCase();
+        return t.contains("안마시") || t.contains("금지") || t.contains("끊") || t.contains("avoid");
+    }
+
+    // 특정 날짜 d에서 "그 날 규칙 충족 여부" 계산
+    private boolean isSatisfiedOn(Challenges c, LocalDate d) {
+        LocalDateTime begin = d.atStartOfDay();
+        LocalDateTime end   = d.atTime(23, 59, 59);
+
+        boolean contains = mealsRepository
+                .existsByUserAndMealDateBetweenAndMenuContainingIgnoreCase(
+                        c.getUser(), begin, end, c.getTargetMenuName()
+                );
+
+        // 회피형: 해당 메뉴가 없어야 충족 / 섭취형: 있으면 충족
+        return isAvoidType(c) ? !contains : contains;
+    }
+
+    // 시작~종료 기간 동안 일별 스탬프(boolean[]) 계산
+    private boolean[] buildDailyStamps(Challenges c) {
+        LocalDate start = c.getStartDate();
+        LocalDate end   = c.getEndDate();
+
+        int days = (int) (end.toEpochDay() - start.toEpochDay()) + 1;
+        boolean[] stamps = new boolean[days];
+
+        LocalDate today = LocalDate.now(KST);
+        for (int i = 0; i < days; i++) {
+            LocalDate d = start.plusDays(i);
+            // 미래 날짜는 미판정 → false 유지 (원하면 DTO를 Boolean[]로 바꿔 null 처리)
+            if (!d.isAfter(today)) {
+                stamps[i] = isSatisfiedOn(c, d);
+            }
+        }
+        return stamps;
+    }
+
+    private boolean hasChallengeEnded(Challenges c) {
+        // endDate < 내일 == 이미 종료
+        return c.getEndDate().isBefore(LocalDate.now(KST).plusDays(1));
+    }
+
+    /* ==========================
+     * 도메인 기능
+     * ========================== */
+
+    // 참여하기
     @Transactional
-    public ChallengeDto.ParticipateResponse participate(Long challengeId) {
+    public ChallengeDto.Response.ParticipateResponse participate(Long challengeId) {
         User user = authService.getCurrentUser();
         Challenges c = challengeRepository.findByChallengeIdAndUser(challengeId, user)
-                .orElseThrow(() -> new NotFoundException("챌린지를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("챌린지를 찾을 수 없습니다."));
         c.participate();
-        return new ChallengeDto.ParticipateResponse(c.getStatus().name());
+        return new ChallengeDto.Response.ParticipateResponse(c.getStatus().name());
     }
 
+    // 포기하기
     @Transactional
-    public ChallengeDto.ParticipateResponse giveUp(Long challengeId) {
+    public ChallengeDto.Response.ParticipateResponse giveUp(Long challengeId) {
         User user = authService.getCurrentUser();
         Challenges c = challengeRepository.findByChallengeIdAndUser(challengeId, user)
-                .orElseThrow(() -> new NotFoundException("챌린지를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("챌린지를 찾을 수 없습니다."));
         c.giveUp();
-        return new ChallengeDto.ParticipateResponse(c.getStatus().name());
+        return new ChallengeDto.Response.ParticipateResponse(c.getStatus().name());
     }
 
+    // 내 챌린지 목록
     @Transactional(readOnly = true)
     public List<Challenges> listMine(String statusesCsv) {
         User user = authService.getCurrentUser();
         List<ChallengeStatus> statuses = Arrays.stream(statusesCsv.split(","))
                 .map(String::trim)
+                .filter(s -> !s.isEmpty())
                 .map(ChallengeStatus::valueOf)
                 .toList();
         return challengeRepository.findAllByUserAndStatusIn(user, statuses);
     }
 
-    /** 매일 00:10에 어제까지 종료된 챌린지를 SUCCESS/FAIL로 판정 */
+    // 스탬프 찍기
+    @Transactional(readOnly = true)
+    public List<ChallengeDto.Response> listMineWithStamps(String statusesCsv) {
+        User user = authService.getCurrentUser();
+        List<ChallengeStatus> statuses = Arrays.stream(statusesCsv.split(","))
+                .map(String::trim).filter(s -> !s.isEmpty())
+                .map(ChallengeStatus::valueOf).toList();
+
+        var challenges = challengeRepository.findAllByUserAndStatusIn(user, statuses);
+
+        List<ChallengeDto.Response> result = new ArrayList<>();
+        for (Challenges c : challenges) {
+            // 기본 상세 DTO
+            ChallengeDto.Response dto = ChallengeConverter.toDetailDto(c);
+
+            // 스탬프/충족일수 채우기 (getDetail과 동일 로직)
+            boolean[] stamps = buildDailyStamps(c);
+            dto.setStamps(stamps);
+            int satisfied = 0; for (boolean s : stamps) if (s) satisfied++;
+            dto.setSatisfiedDays(satisfied);
+
+            result.add(dto);
+        }
+        return result;
+    }
+    /**
+     * ✅ [추가] 참여 전, 내 계정에 "생성되어 있는" 전체 챌린지 조회 (라이트)
+     * - 정의: 보통 PENDING(후보) 상태 = 아직 참여/포기/성공/실패 결정 전
+     * - 정렬: 시작일 최신순 (최근에 생성된 후보가 위로 오도록)
+     * - 반환: 목록 화면용 경량 DTO (toDto)
+     */
+    @Transactional(readOnly = true)
+    public List<ChallengeDto.Response> listAvailableAll() {
+        User user = authService.getCurrentUser();
+
+        // 기존 findAllByUserAndStatusIn 재사용 (레포 메서드 추가 불필요)
+        var entities = challengeRepository.findAllByUserAndStatusIn(
+                user, List.of(ChallengeStatus.PENDING)
+        );
+
+        return entities.stream()
+                .sorted(Comparator.comparing(Challenges::getStartDate).reversed())
+                .map(ChallengeConverter::toDto)
+                .toList();
+    }
+
+    // 참여 중인 챌린지(IN_PROGRESS)만 스탬프 포함해 반환
+    @Transactional(readOnly = true)
+    public List<ChallengeDto.Response> listParticipatingWithStamps() {
+        User user = authService.getCurrentUser();
+
+        // IN_PROGRESS만 조회
+        var challenges = challengeRepository.findAllByUserAndStatusIn(
+                user, List.of(ChallengeStatus.IN_PROGRESS)
+        );
+
+        List<ChallengeDto.Response> result = new ArrayList<>();
+        for (Challenges c : challenges) {
+            ChallengeDto.Response dto = ChallengeConverter.toDetailDto(c);
+
+            // 참여 중일 때만 스탬프 계산/세팅
+            boolean[] stamps = buildDailyStamps(c);
+            dto.setStamps(stamps);
+            int satisfied = 0; for (boolean s : stamps) if (s) satisfied++;
+            dto.setSatisfiedDays(satisfied);
+
+            result.add(dto);
+        }
+        return result;
+    }
+
+    /**
+     * 챌린지 상세조회
+     * - 로그인한 사용자의 챌린지 중에서 challengeId로 찾음
+     * - 응답 DTO에 일별 스탬프/충족일수 포함
+     */
+    @Transactional(readOnly = true)
+    public ChallengeDto.Response getDetail(Long challengeId, Long currentUserId) {
+        User currentUser = authService.getCurrentUser();
+        Challenges c = challengeRepository.findByChallengeIdAndUser(challengeId, currentUser)
+                .orElseThrow(() -> new EntityNotFoundException("해당 챌린지를 찾을 수 없습니다."));
+
+        ChallengeDto.Response dto = ChallengeConverter.toDetailDto(c);
+
+        // 참여 중(IN_PROGRESS)일 때만 스탬프 계산/세팅
+        if (c.getStatus() != ChallengeStatus.PENDING) {
+            boolean[] stamps = buildDailyStamps(c);
+            dto.setStamps(stamps);
+            int satisfied = 0; for (boolean s : stamps) if (s) satisfied++;
+            dto.setSatisfiedDays(satisfied);
+        } else {
+            // 스탬프 숨김(원하면 null 세팅)
+            dto.setStamps(null);
+            dto.setSatisfiedDays(0);
+        }
+
+        return dto;
+    }
+
+    /**
+     * 종료 챌린지 판정 (스케줄 호출은 ChallengeScheduler에서)
+     * - 회피형: 모든 날 충족 → SUCCESS
+     * - 섭취형: 1일 이상 충족 → SUCCESS   (필요 시 요구치 컬럼과 비교)
+     */
     @Transactional
     public void evaluateDaily() {
         LocalDate today = LocalDate.now(KST);
@@ -71,29 +233,44 @@ public class ChallengeService {
         );
 
         for (Challenges c : targets) {
-            LocalDateTime startDt = c.getStartDate().atStartOfDay();
-            LocalDateTime endDt = c.getEndDate().atTime(23, 59, 59);
+            boolean[] stamps = buildDailyStamps(c);
+            int satisfied = 0;
+            for (boolean s : stamps) if (s) satisfied++;
 
-            boolean ok = mealsRepository.existsByUserAndMealDateBetweenAndMenuContainingIgnoreCase(
-                    c.getUser(), startDt, endDt, c.getTargetMenuName()
-            );
-            if (ok) c.success(LocalDateTime.now(KST));
+            boolean success = isAvoidType(c)
+                    ? (satisfied == stamps.length)  // 회피형: 전일 충족
+                    : (satisfied >= 1);             // 섭취형: 기본 1일 이상
+
+            if (success) c.success(LocalDateTime.now(KST));
             else c.fail();
         }
     }
 
+    /* ==========================
+     * 리뷰 (0~5점, 종료 후만)
+     * ========================== */
+
     @Transactional
-    public ChallengeDto.ReviewResponse createReview(Long challengeId, ChallengeDto.ReviewCreateOrUpdateRequest req) {
-        if (req.getRating() == null || req.getRating() < 1 || req.getRating() > 5) {
-            throw new IllegalArgumentException("별점은 1~5 범위여야 합니다.");
+    public ChallengeDto.Response.ReviewResponse createReview(
+            Long challengeId,
+            ChallengeDto.Response.ReviewCreateOrUpdateRequest req
+    ) {
+        // 0~5 허용
+        if (req.getRating() == null || req.getRating() < 0 || req.getRating() > 5) {
+            throw new IllegalArgumentException("별점은 0~5 범위여야 합니다.");
         }
         User user = authService.getCurrentUser();
-        Challenges challenge = challengeRepository.findByChallengeIdAndUser(challengeId, user)
-                .orElseThrow(() -> new NotFoundException("챌린지를 찾을 수 없습니다."));
+        Challenges c = challengeRepository.findByChallengeIdAndUser(challengeId, user)
+                .orElseThrow(() -> new EntityNotFoundException("챌린지를 찾을 수 없습니다."));
+
+        // 종료 후만 작성 가능
+        if (!hasChallengeEnded(c)) {
+            throw new IllegalStateException("챌린지 종료 후에만 리뷰를 작성할 수 있습니다.");
+        }
 
         ChallengeReviews review = reviewRepository.save(
                 ChallengeReviews.builder()
-                        .challenge(challenge)
+                        .challenge(c)
                         .user(user)
                         .rating(req.getRating())
                         .content(req.getContent())
@@ -102,37 +279,44 @@ public class ChallengeService {
         return toReviewDto(review);
     }
 
+    // 별점 및 후기 작성
     @Transactional
-    public ChallengeDto.ReviewResponse updateReview(Long reviewId, ChallengeDto.ReviewCreateOrUpdateRequest req) {
+    public ChallengeDto.Response.ReviewResponse updateReview(
+            Long reviewId,
+            ChallengeDto.Response.ReviewCreateOrUpdateRequest req
+    ) {
         User user = authService.getCurrentUser();
         ChallengeReviews review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new NotFoundException("후기를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("후기를 찾을 수 없습니다."));
         if (!review.getUser().getId().equals(user.getId())) {
             throw new IllegalStateException("본인 후기만 수정할 수 있습니다.");
         }
         if (req.getRating() != null) {
-            if (req.getRating() < 1 || req.getRating() > 5) {
-                throw new IllegalArgumentException("별점은 1~5 범위여야 합니다.");
+            if (req.getRating() < 0 || req.getRating() > 5) {
+                throw new IllegalArgumentException("별점은 0~5 범위여야 합니다.");
             }
             review.setRating(req.getRating());
         }
-        review.setContent(req.getContent());
+        if (req.getContent() != null) {
+            review.setContent(req.getContent());
+        }
         return toReviewDto(review);
     }
 
+    // 후기 삭제
     @Transactional
     public void deleteReview(Long reviewId) {
         User user = authService.getCurrentUser();
         ChallengeReviews review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new NotFoundException("후기를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("후기를 찾을 수 없습니다."));
         if (!review.getUser().getId().equals(user.getId())) {
             throw new IllegalStateException("본인 후기만 삭제할 수 있습니다.");
         }
         reviewRepository.delete(review);
     }
 
-    private ChallengeDto.ReviewResponse toReviewDto(ChallengeReviews r) {
-        ChallengeDto.ReviewResponse dto = new ChallengeDto.ReviewResponse();
+    private ChallengeDto.Response.ReviewResponse toReviewDto(ChallengeReviews r) {
+        ChallengeDto.Response.ReviewResponse dto = new ChallengeDto.Response.ReviewResponse();
         dto.setReviewId(r.getReviewId());
         dto.setChallengeId(r.getChallenge().getChallengeId());
         dto.setRating(r.getRating());
@@ -141,4 +325,21 @@ public class ChallengeService {
         dto.setUpdatedAt(r.getUpdatedAt());
         return dto;
     }
+
+    // ChallengeService.java
+
+    @Transactional(readOnly = true)
+    public List<ChallengeDto.Response> listCurrentGeneratedChallenges() {
+        User user = authService.getCurrentUser();
+
+        // ✅ 현재 사용자에게 생성된 모든 챌린지를 최신순으로 조회
+        List<Challenges> challenges = challengeRepository
+                .findAllByUserOrderByStartDateDesc(user);
+
+        // ✅ 가벼운 DTO로 변환 (스탬프 불필요)
+        return challenges.stream()
+                .map(ChallengeConverter::toDto)
+                .toList();
+    }
+
 }

--- a/src/main/java/snapmeal/snapmeal/service/S3UploadService.java
+++ b/src/main/java/snapmeal/snapmeal/service/S3UploadService.java
@@ -10,6 +10,8 @@ import org.springframework.web.multipart.MultipartFile;
 import snapmeal.snapmeal.config.S3Configure;
 import snapmeal.snapmeal.domain.Images;
 import snapmeal.snapmeal.domain.User;
+import snapmeal.snapmeal.global.GeneralException;
+import snapmeal.snapmeal.global.code.ErrorCode;
 import snapmeal.snapmeal.global.util.AuthService;
 import snapmeal.snapmeal.repository.ImageRepository;
 import snapmeal.snapmeal.web.dto.DetectionDto;
@@ -30,56 +32,69 @@ public class S3UploadService {
     private final AuthService authService;
     private final StringHttpMessageConverter stringHttpMessageConverter;
 
+    private static final long MAX_FILE_SIZE = 100 * 1024 * 1024; // 이미지 최대 사이즈 2MB
+
     @Transactional
-    public PredictionResponseDto uploadPredictAndSave(MultipartFile file) throws IOException {
-        // 로그인한 사용자 가져오기
-        User user = authService.getCurrentUser();
+    public PredictionResponseDto uploadPredictAndSave(MultipartFile file) {
+        try {
+            if (file.getSize() > MAX_FILE_SIZE) {
+                throw new GeneralException(ErrorCode.INVALID_INPUT_VALUE,
+                        "이미지 용량이 2MB를 초과했습니다. 최대 100MB까지 업로드 가능합니다.");
+            }
+            // 로그인한 사용자 가져오기
+            User user = authService.getCurrentUser();
 
-        // 파일 이름 생성 (UUID-원본파일명)
-        String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
+            // 파일 이름 생성 (UUID-원본파일명)
+            String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
 
-        // 메타데이터 생성
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentLength(file.getSize());
-        metadata.setContentType(file.getContentType());
+            // 메타데이터 생성
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(file.getSize());
+            metadata.setContentType(file.getContentType());
 
-        // S3에 업로드
-        String bucket = s3Configure.getBucket();
-        amazonS3.putObject(bucket, fileName, file.getInputStream(), metadata);
+            // S3에 업로드
+            String bucket = s3Configure.getBucket();
+            amazonS3.putObject(bucket, fileName, file.getInputStream(), metadata);
 
-        // 업로드된 파일 URL 얻기
-        String fileUrl = amazonS3.getUrl(bucket, fileName).toString();
+            // 업로드된 파일 URL 얻기
+            String fileUrl = amazonS3.getUrl(bucket, fileName).toString();
 
-        // 예측 서버에 요청
-        PredictionResponseDto predictionResponse = fastApiProxyService.sendImageUrlToFastApi(fileUrl);
+            // 예측 서버에 요청
+            PredictionResponseDto predictionResponse = fastApiProxyService.sendImageUrlToFastApi(fileUrl);
 
-        // 예측 결과에서 모든 detections 리스트 꺼내기
-        List<DetectionDto> detections = predictionResponse.getDetections();
+            // 예측 결과에서 모든 detections 리스트 꺼내기
+            List<DetectionDto> detections = predictionResponse.getDetections();
 
-        // detections가 비어있으면 Unknown 하나로 저장
-        // 엔티티 저장: 대표 정보로 첫 번째 감지 객체 선택(없으면 기본값)
-        int classId = -1;
-        String className = "Unknown";
-        if (detections != null && !detections.isEmpty()) {
-            DetectionDto top = detections.get(0);
-            classId = top.getClassId();
-            className = top.getClassName();
+            // detections가 비어있으면 Unknown 하나로 저장
+            // 엔티티 저장: 대표 정보로 첫 번째 감지 객체 선택(없으면 기본값)
+            int classId = -1;
+            String className = "Unknown";
+            if (detections != null && !detections.isEmpty()) {
+                DetectionDto top = detections.get(0);
+                classId = top.getClassId();
+                className = top.getClassName();
+            }
+
+            Images image = Images.builder()
+                    .imageUrl(fileUrl)
+                    .user(user)
+                    .classId(classId)
+                    .className(className)
+                    .build();
+
+            Images saved = imagesRepository.save(image);
+
+            // DTO에 ID와 detections 세팅 후 리턴
+            predictionResponse.setImageId(Collections.singletonList(saved.getImgId()));
+            predictionResponse.setDetections(detections);
+
+            // 예측 결과 URL 리턴
+            return predictionResponse;
+        } catch (GeneralException e) {
+            throw e;
+        }catch (Exception e) {
+            throw new GeneralException(ErrorCode.INTERNAL_SERVER_ERROR,
+                    "이미지 업로드 또는 예측 중 오류가 발생했습니다.");
         }
-
-        Images image = Images.builder()
-                .imageUrl(fileUrl)
-                .user(user)
-                .classId(classId)
-                .className(className)
-                .build();
-
-        Images saved = imagesRepository.save(image);
-
-        // DTO에 ID와 detections 세팅 후 리턴
-        predictionResponse.setImageId(Collections.singletonList(saved.getImgId()));
-        predictionResponse.setDetections(detections);
-
-        // 예측 결과 URL 리턴
-        return predictionResponse;
     }
 }

--- a/src/main/java/snapmeal/snapmeal/web/controller/ChallengeController.java
+++ b/src/main/java/snapmeal/snapmeal/web/controller/ChallengeController.java
@@ -3,9 +3,10 @@ package snapmeal.snapmeal.web.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.*;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import snapmeal.snapmeal.domain.Challenges;
+import snapmeal.snapmeal.converter.ChallengeConverter;
 import snapmeal.snapmeal.global.util.AuthService;
 import snapmeal.snapmeal.service.ChallengeGeneratorService;
 import snapmeal.snapmeal.service.ChallengeService;
@@ -27,51 +28,129 @@ public class ChallengeController {
     @Operation(summary = "내 챌린지 목록 조회")
     @GetMapping("/my")
     public List<ChallengeDto.Response> listMine(
-            @RequestParam(required = false, defaultValue = "IN_PROGRESS,SUCCESS,PENDING") String statuses
+            @RequestParam(required = false, defaultValue = "IN_PROGRESS,SUCCESS,PENDING,FAIL") String statuses
     ) {
-        return challengeService.listMine(statuses).stream().map(this::toDto).toList();
+        // 서비스에서 stamps/satisfiedDays/introduction/participation까지 채워진 DTO 리턴
+        return challengeService.listMineWithStamps(statuses);
     }
 
     @Operation(summary = "챌린지 참여하기")
     @ApiResponse(responseCode = "200", content = @Content(
             mediaType = "application/json",
-            examples = @ExampleObject(value = "{ \"status\": \"IN_PROGRESS\" }"),
-            schema = @Schema(implementation = ChallengeDto.ParticipateResponse.class)
+            schema = @Schema(implementation = ChallengeDto.Response.ParticipateResponse.class),
+            examples = @ExampleObject(value = "{ \"status\": \"IN_PROGRESS\" }")
     ))
     @PostMapping("/{challengeId}/participate")
-    public ChallengeDto.ParticipateResponse participate(@PathVariable Long challengeId) {
+    public ChallengeDto.Response.ParticipateResponse participate(@PathVariable Long challengeId) {
         return challengeService.participate(challengeId);
     }
 
     @Operation(summary = "챌린지 포기하기")
+    @ApiResponse(responseCode = "200", content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ChallengeDto.Response.ParticipateResponse.class),
+            examples = @ExampleObject(value = "{ \"status\": \"CANCELLED\" }")
+    ))
     @PostMapping("/{challengeId}/give-up")
-    public ChallengeDto.ParticipateResponse giveUp(@PathVariable Long challengeId) {
+    public ChallengeDto.Response.ParticipateResponse giveUp(@PathVariable Long challengeId) {
         return challengeService.giveUp(challengeId);
+    }
+
+    @Operation(
+            summary = "챌린지 상세조회",
+            description = """
+        사용자가 선택한 챌린지의 상세 정보를 반환합니다.  
+        반환 데이터에는 제목, 커버 이미지, 목표, 상세 설명, 기간, 상태, 참여 여부 등이 포함됩니다.
+        """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공적으로 조회됨",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ChallengeDto.Response.class),
+                            examples = @ExampleObject(value =
+                                    "{\n" +
+                                            "  \"challengeId\": 1,\n" +
+                                            "  \"title\": \"커피 마시지 않기\",\n" +
+                                            "  \"coverImageUrl\": \"https://cdn.snapmeal.app/challenges/coffee-off.png\",\n" +
+                                            "  \"targetMenuName\": \"커피\",\n" +
+                                            "  \"description\": \"아메리카노, 에스프레소, 라떼 등 모든 커피 종류 포함\",\n" +
+                                            "  \"status\": \"PENDING\",\n" +
+                                            "  \"startDate\": \"2025-10-20\",\n" +
+                                            "  \"endDate\": \"2025-10-26\",\n" +
+                                            "  \"introduction\": {\n" +
+                                            "    \"mainGoal\": \"커피 안마시기\",\n" +
+                                            "    \"purpose\": \"카페인 줄이기 및 건강 관리\",\n" +
+                                            "    \"detailDescription\": \"아메리카노, 에스프레소, 라떼 등 모든 커피 종류 포함\",\n" +
+                                            "    \"weeklyTarget\": \"주 5회 이상\",\n" +
+                                            "    \"successCondition\": \"기간 동안 커피 관련 미기록시 성공\"\n" +
+                                            "  },\n" +
+                                            "  \"participation\": {\n" +
+                                            "    \"isParticipating\": false,\n" +
+                                            "    \"participatedAt\": null\n" +
+                                            "  }\n" +
+                                            "}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 챌린지를 찾을 수 없음",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    @GetMapping("/{challengeId}")
+    public ChallengeDto.Response getChallengeDetail(@PathVariable Long challengeId) {
+        var currentUser = authService.getCurrentUser();
+        return challengeService.getDetail(challengeId, currentUser.getId());
+    }
+
+
+    // 참여 전 후보(PENDING) 목록: 스탬프 없음
+    @Operation(
+            summary = "참여 전 챌린지 목록(PENDING): 스탬프 미포함",
+            description = "사용자가 참여 전인 챌린지 목록을 보여줍니다."
+    )
+    @GetMapping("/my/available")
+    public List<ChallengeDto.Response> listMyAvailableAll() {
+        return challengeService.listAvailableAll();
+    }
+
+    // 참여 중 목록: 스탬프 포함
+    @Operation(
+            summary = "참여 중 챌린지 목록: 스탬프 포함",
+            description = "사용자가 참여중인 챌린지 목록을 보여줍니다."
+    )
+    @GetMapping("/my/participating")
+    public List<ChallengeDto.Response> listMyParticipatingWithStamps() {
+        return challengeService.listParticipatingWithStamps();
+    }
+
+    // 챌린지 전체 목록 조회
+    @Operation(
+            summary = "현재 생성되어 있는 모든 챌린지 조회",
+            description = "전체 챌린지 목록을 조회합니다."
+    )
+    @GetMapping("/all")
+    public List<ChallengeDto.Response> listCurrentGeneratedChallenges() {
+        return challengeService.listCurrentGeneratedChallenges();
     }
 
     // (테스트용) 이번 주 3개 생성 — 현재 로그인 사용자 기준
     @PostMapping("/weekly/generate")
-    public List<ChallengeDto.Response> generateWeeklyForMe() {
+    public List<ChallengeDto.Response> generateWeeklyForMe(@RequestParam(defaultValue = "false") boolean force) {
         var user = authService.getCurrentUser();
         LocalDate today = LocalDate.now();
         LocalDate weekStart = today.with(DayOfWeek.MONDAY);
         LocalDate weekEnd = weekStart.plusDays(6);
-        return generatorService.generateWeeklyForUser(user, weekStart, weekEnd)
-                .stream().map(this::toDto).toList();
-    }
 
-    private ChallengeDto.Response toDto(Challenges c) {
-        return ChallengeDto.Response.builder()
-                .challengeId(c.getChallengeId())
-                .title(c.getTitle())
-                .targetMenuName(c.getTargetMenuName())
-                .description(c.getDescription())
-                .startDate(c.getStartDate())
-                .endDate(c.getEndDate())
-                .status(c.getStatus().name())
-                .participatedAt(c.getParticipatedAt())
-                .completedAt(c.getCompletedAt())
-                .cancelledAt(c.getCancelledAt())
-                .build();
+        var created = generatorService.generateWeeklyForUser(user, weekStart, weekEnd, force);
+
+        // 각 챌린지에 대해 서비스의 getDetail을 호출해서
+        // stamps / satisfiedDays / introduction / participation 이 꽉 찬 DTO로 반환
+        return created.stream()
+                .map(c -> challengeService.getDetail(c.getChallengeId(), user.getId()))
+                .toList();
     }
 }

--- a/src/main/java/snapmeal/snapmeal/web/controller/MealsController.java
+++ b/src/main/java/snapmeal/snapmeal/web/controller/MealsController.java
@@ -44,7 +44,7 @@ public class MealsController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.onSuccess(response));
     }
 
-    @GetMapping
+    @GetMapping("/date")
     @Operation(
             summary = "하루 식단 조회 API",
             description = "사용자의 하루 식단 목록을 조회합니다. " +
@@ -59,6 +59,33 @@ public class MealsController {
     ) {
         List<MealsResponseDto> response = mealsService.getMealsByDate(date);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    // 식단 기록 전체 조회
+    @GetMapping
+    @Operation(
+            summary = "내 식사기록 전체 조회",
+            description = "로그인 사용자의 모든 식사 기록을 최신순으로 반환합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "내 식사기록 조회 성공",
+            content = @Content(schema = @Schema(implementation = ApiResponse.class))
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.USER_NOT_FOUND
+    })
+    public ResponseEntity<ApiResponse<List<MealsResponseDto>>> listMyMeals(
+            @AuthenticationPrincipal User loginUser
+    ) {
+        // 서비스에서 엔티티 목록을 가져와 DTO로 변환
+        List<MealsResponseDto> result = mealsService
+                .getMyMeals(loginUser)
+                .stream()
+                .map(MealsResponseDto::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
 

--- a/src/main/java/snapmeal/snapmeal/web/dto/ChallengeDto.java
+++ b/src/main/java/snapmeal/snapmeal/web/dto/ChallengeDto.java
@@ -16,11 +16,16 @@ public class ChallengeDto {
         @Schema(example = "커피 마시기")
         private String title;
 
+        private String coverImageUrl; // 상단 배너 이미지
+
         @Schema(example = "커피")
         private String targetMenuName;
 
-        @Schema(example = "오늘은 아메리카노 한 잔!")
+        @Schema(example = "아메리카노, 에스프레소, 라떼 등 모든 커피 종류 포함")
         private String description;
+
+        @Schema(example = "IN_PROGRESS")
+        private String status;
 
         @Schema(example = "2025-09-01")
         private LocalDate startDate;
@@ -28,41 +33,85 @@ public class ChallengeDto {
         @Schema(example = "2025-09-07")
         private LocalDate endDate;
 
-        @Schema(example = "IN_PROGRESS")
-        private String status;
+        // ✅ 회피형 여부(엔티티 컬럼 도입 시 매핑)
+        @Schema(example = "true", description = "회피형 챌린지 여부 (예: 커피 안마시기)")
+        private Boolean isAvoidType;
 
-        private LocalDateTime participatedAt;
-        private LocalDateTime completedAt;
-        private LocalDateTime cancelledAt;
-    }
+        // ✅ 스탬프: 1일차~N일차, 각 날짜 충족 여부
+        @Schema(example = "[true,false,true,false,true,false,true]", description = "1일차~N일차 일별 충족 여부")
+        private boolean[] stamps;
 
-    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
-    public static class ParticipateResponse {
-        @Schema(example = "\"IN_PROGRESS\"")
-        private String status;
-    }
+        // ✅ 충족 일수 (UI 요약용)
+        @Schema(example = "4", description = "충족한 일수 합계")
+        private int satisfiedDays;
 
-    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
-    public static class ReviewCreateOrUpdateRequest {
-        @Schema(example = "5")
-        private Integer rating;  // 1~5
+        private Introduction introduction;    // 소개 섹션
+        private ParticipationInfo participation; // 참여 정보
 
-        @Schema(example = "재밌었다~!")
-        private String content;
-    }
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
+        public static class Introduction {
+            private String mainGoal;          // 주 목표 (예: 커피 안마시기)
+            private String purpose;           // 목적 (예: 카페인 줄이기 및 건강 관리)
+            private String detailDescription; // 상세설명
+            private String weeklyTarget;      // 달성 목표 (예: 주 5회 이상)
+            private String successCondition;  // 달성 조건 (예: 기간 동안 커피 관련 미기록시 성공)
+        }
 
-    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
-    public static class ReviewResponse {
-        private Long reviewId;
-        private Long challengeId;
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
+        public static class ParticipationInfo {
+            // 참여 중이면 true -> '참여하기' 버튼 비활성화 용
+            @com.fasterxml.jackson.annotation.JsonProperty("isParticipating")
+            private boolean isParticipating;
+            // 참여 시작 시각 (참여 안했으면 null)
+            private LocalDateTime participatedAt;
+        }
 
-        @Schema(example = "5")
-        private Integer rating;
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class ParticipateResponse {
+            @Schema(example = "\"IN_PROGRESS\"")
+            private String status;
+        }
 
-        @Schema(example = "다음에 또 해야지!")
-        private String content;
+        /* ---------- 리뷰 DTO ---------- */
 
-        private LocalDateTime createdAt;
-        private LocalDateTime updatedAt;
+        // ✅ 요청 DTO는 "입력"에만 쓰이므로 Response 내부 보관해도 되지만,
+        // 나중에 분리하고 싶으면 ChallengeReviewRequestDto로 빼면 깔끔.
+        @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+        public static class ReviewCreateOrUpdateRequest {
+            // ✅ 별점 0~5로 수정 (요구사항 반영) — 서버 검증도 0~5로 변경했는지 확인!
+            @Schema(example = "4", minimum = "0", maximum = "5")
+            private Integer rating;
+            @Schema(example = "생각보다 힘들었지만 몸이 가벼워졌어요!")
+            private String content;
+        }
+
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class ReviewResponse {
+            private Long reviewId;
+            private Long challengeId;
+
+            @Schema(example = "5")
+            private Integer rating;
+
+            @Schema(example = "다음에 또 해야지!")
+            private String content;
+
+            private LocalDateTime createdAt;
+            private LocalDateTime updatedAt;
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,11 +65,11 @@ spring:
       enabled: true
   data:
     redis:
-#      host: redis-container
-      host: localhost
+      host: redis-container
+#      host: localhost
       port: 6379
   # 사진 최대 업로드 크기 늘리기
   servlet:
     multipart:
-      max-file-size: 2MB
-      max-request-size: 2MB
+      max-file-size: 100MB
+      max-request-size: 100MB


### PR DESCRIPTION
## #️⃣연관된 이슈

> #20 

## 📝작업 내용 & 스크린샷

>
1. 챌린지 스탬프, 리뷰 작성 로직 추가
<img width="1079" height="810" alt="image" src="https://github.com/user-attachments/assets/e64eac86-f4eb-4863-b488-ef5f9839fb04" />

2. 챌린지 생성 오류 수정 (목록에 있는 메뉴로만 챌린지 생성하도록  수정 완료)
<img width="1087" height="845" alt="image" src="https://github.com/user-attachments/assets/53fe3e58-e35c-44ee-8680-453eaf5c9733" />

3. 식사 기록 전체 조회 
<img width="1151" height="861" alt="image" src="https://github.com/user-attachments/assets/8543eee3-67e0-4ec1-828b-2fcabd718892" />

## 💬리뷰 요구사항(선택)

> 로직 수정해서 다시 올리겠습니다..!!!