### PR TITLE
Fix, Feat: : 챌린지 리뷰 Fail 수정 & 리뷰 조회 기능 추가

### DIFF
--- a/src/main/java/snapmeal/snapmeal/converter/ChallengeConverter.java
+++ b/src/main/java/snapmeal/snapmeal/converter/ChallengeConverter.java
@@ -1,6 +1,7 @@
 package snapmeal.snapmeal.converter;
 
 import org.springframework.stereotype.Component;
+import snapmeal.snapmeal.domain.ChallengeReviews;
 import snapmeal.snapmeal.domain.Challenges;
 import snapmeal.snapmeal.domain.enums.ChallengeStatus;
 import snapmeal.snapmeal.web.dto.ChallengeDto;
@@ -47,7 +48,7 @@ public class ChallengeConverter {
                 .status(c.getStatus().name())
                 .startDate(c.getStartDate())
                 .endDate(c.getEndDate())
-                // ✅ 회피형 여부
+                // 회피형 여부
                 .isAvoidType(c.isAvoidType())
                 // 소개 섹션: 엔티티에 전용 칼럼이 없으면 규칙/상수로 보강
                 .introduction(ChallengeDto.Response.Introduction.builder()
@@ -126,5 +127,4 @@ public class ChallengeConverter {
             return String.format("기간(%d일) 동안 \"%s\" 기록 1일 이상 시 성공", days, c.getTargetMenuName());
         }
     }
-
 }

--- a/src/main/java/snapmeal/snapmeal/domain/Challenges.java
+++ b/src/main/java/snapmeal/snapmeal/domain/Challenges.java
@@ -90,16 +90,22 @@ public class Challenges extends BaseEntity {
         this.cancelledAt = java.time.LocalDateTime.now();
     }
 
-    /** 자정 배치에서 성공 판정 시 호출 */
+    // 자정 배치에서 성공 판정 시 호출
     public void success(java.time.LocalDateTime when) {
         this.status = ChallengeStatus.SUCCESS;
         this.completedAt = when;
     }
 
-    /** 기간 종료 시 실패로 마감 */
+    // 기간 종료 시 실패로 마감
     public void fail() {
         if (this.status == ChallengeStatus.PENDING || this.status == ChallengeStatus.IN_PROGRESS) {
             this.status = ChallengeStatus.FAIL;
         }
+    }
+
+    @Enumerated(EnumType.STRING)
+    // 기간 종료 시, 참여하지 않은 챌린지 처리
+    public void markNotParticipated() {
+        this.status = ChallengeStatus.NOT_PARTICIPATED;
     }
 }

--- a/src/main/java/snapmeal/snapmeal/domain/enums/ChallengeStatus.java
+++ b/src/main/java/snapmeal/snapmeal/domain/enums/ChallengeStatus.java
@@ -5,5 +5,6 @@ public enum ChallengeStatus {
         IN_PROGRESS,   // 사용자가 참여 버튼을 눌러 도전 중
         SUCCESS,       // 성공(자정 배치가 식사기록을 보고 성공으로 판정)
         FAIL,          // 기간 끝났는데 성공 못함
-        CANCELLED      // 사용자가 포기하기 버튼을 눌러 취소
+        CANCELLED,     // 사용자가 포기하기 버튼을 눌러 취소
+        NOT_PARTICIPATED // 기간 끝날 때까지 아예 참여 안 함
 }

--- a/src/main/java/snapmeal/snapmeal/repository/ChallengeReviewRepository.java
+++ b/src/main/java/snapmeal/snapmeal/repository/ChallengeReviewRepository.java
@@ -6,8 +6,11 @@ import snapmeal.snapmeal.domain.Challenges;
 import snapmeal.snapmeal.domain.ChallengeReviews;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChallengeReviewRepository extends JpaRepository<ChallengeReviews, Long> {
-    List<ChallengeReviews> findAllByChallenge(Challenges challenge);
-    List<ChallengeReviews> findAllByUser(User user);
+    Optional<ChallengeReviews> findByChallenge(Challenges challenge);
+
+    // 내가 쓴 리뷰 전체, 최신순
+    List<ChallengeReviews> findAllByUserOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/snapmeal/snapmeal/service/ChallengeService.java
+++ b/src/main/java/snapmeal/snapmeal/service/ChallengeService.java
@@ -146,7 +146,7 @@ public class ChallengeService {
         return result;
     }
     /**
-     * ✅ [추가] 참여 전, 내 계정에 "생성되어 있는" 전체 챌린지 조회 (라이트)
+     * 참여 전, 내 계정에 "생성되어 있는" 전체 챌린지 조회
      * - 정의: 보통 PENDING(후보) 상태 = 아직 참여/포기/성공/실패 결정 전
      * - 정렬: 시작일 최신순 (최근에 생성된 후보가 위로 오도록)
      * - 반환: 목록 화면용 경량 DTO (toDto)
@@ -227,22 +227,36 @@ public class ChallengeService {
     @Transactional
     public void evaluateDaily() {
         LocalDate today = LocalDate.now(KST);
-        List<Challenges> targets = challengeRepository.findAllByStatusInAndEndDateLessThanEqual(
-                List.of(ChallengeStatus.PENDING, ChallengeStatus.IN_PROGRESS),
-                today.minusDays(1)
-        );
+
+        // PENDING + IN_PROGRESS 중 어제까지 끝난 챌린지만 판정 대상
+        List<Challenges> targets = challengeRepository
+                .findAllByStatusInAndEndDateLessThanEqual(
+                        List.of(ChallengeStatus.PENDING, ChallengeStatus.IN_PROGRESS),
+                        today.minusDays(1)  // 어제까지 끝난 챌린지
+                );
 
         for (Challenges c : targets) {
+
+            // 끝날 때까지 참여 안 한 챌린지 -> NOT_PARTICIPATED
+            if (c.getStatus() == ChallengeStatus.PENDING) {
+                c.markNotParticipated();
+                continue;
+            }
+
+            // 여기 오면 무조건 IN_PROGRESS -> 성공/실패 판정
             boolean[] stamps = buildDailyStamps(c);
             int satisfied = 0;
             for (boolean s : stamps) if (s) satisfied++;
 
             boolean success = isAvoidType(c)
-                    ? (satisfied == stamps.length)  // 회피형: 전일 충족
-                    : (satisfied >= 1);             // 섭취형: 기본 1일 이상
+                    ? (satisfied == stamps.length)  // 회피형: 전부 만족했을 때만 성공
+                    : (satisfied >= 1);             // 섭취형: 1일이라도 만족하면 성공
 
-            if (success) c.success(LocalDateTime.now(KST));
-            else c.fail();
+            if (success) {
+                c.success(LocalDateTime.now(KST)); // SUCCESS + 종료시간 기록
+            } else {
+                c.fail(); // FAIL
+            }
         }
     }
 
@@ -266,6 +280,11 @@ public class ChallengeService {
         // 종료 후만 작성 가능
         if (!hasChallengeEnded(c)) {
             throw new IllegalStateException("챌린지 종료 후에만 리뷰를 작성할 수 있습니다.");
+        }
+        // 포기하거나 미참여 챌린지 리뷰 작성 불가능
+        if (c.getStatus() == ChallengeStatus.NOT_PARTICIPATED
+                || c.getStatus() == ChallengeStatus.CANCELLED) {
+            throw new IllegalStateException("참여 중이거나 완료된 챌린지만 리뷰를 작성할 수 있습니다.");
         }
 
         ChallengeReviews review = reviewRepository.save(
@@ -341,5 +360,72 @@ public class ChallengeService {
                 .map(ChallengeConverter::toDto)
                 .toList();
     }
+    /**
+     * 특정 챌린지에 작성된 리뷰 단건 조회
+     *  - 챌린지 당 1개의 리뷰만 존재
+     *  - 없으면 null 혹은 예외 처리(필요에 따라 선택)
+     */
+    @Transactional(readOnly = true)
+    public ChallengeDto.Response.ReviewResponse getReview(Long challengeId) {
+        User user = authService.getCurrentUser();
 
+        // 챌린지가 내 소유인지 확인
+        Challenges challenge = challengeRepository
+                .findByChallengeIdAndUser(challengeId, user)
+                .orElseThrow(() -> new EntityNotFoundException("챌린지를 찾을 수 없습니다."));
+
+        // 리뷰 단건 조회
+        ChallengeReviews review = reviewRepository
+                .findByChallenge(challenge)
+                .orElse(null);  // 리뷰가 없을 때 -> null 반환
+
+        // DTO 변환 (null 처리 가능)
+        return (review != null) ? toReviewDto(review) : null;
+    }
+
+    // 내가 작성한 챌린지 리뷰 전체 조회
+    @Transactional(readOnly = true)
+    public List<ChallengeDto.Response.ReviewResponse> listMyReviews() {
+        User user = authService.getCurrentUser();
+
+        // 내가 쓴 리뷰들 최신순 조회
+        List<ChallengeReviews> reviews =
+                reviewRepository.findAllByUserOrderByCreatedAtDesc(user);
+
+        // DTO로 변환
+        return reviews.stream()
+                .map(this::toReviewDto)
+                .toList();
+    }
+
+    /**
+     * ⚠️ 테스트용 리뷰 생성 (기간/상태 제한 없이 강제 생성)
+     * 실제 운영에서는 사용 X
+     */
+    @Transactional
+    public ChallengeDto.Response.ReviewResponse createReviewForTest(
+            Long challengeId,
+            ChallengeDto.Response.ReviewCreateOrUpdateRequest req
+    ) {
+        // 0~5 허용
+        if (req.getRating() == null || req.getRating() < 0 || req.getRating() > 5) {
+            throw new IllegalArgumentException("별점은 0~5 범위여야 합니다.");
+        }
+
+        User user = authService.getCurrentUser();
+        Challenges c = challengeRepository.findByChallengeIdAndUser(challengeId, user)
+                .orElseThrow(() -> new EntityNotFoundException("챌린지를 찾을 수 없습니다."));
+
+        // 기간/상태 무시하고 리뷰 바로 저장 (테스트용)
+        ChallengeReviews review = reviewRepository.save(
+                ChallengeReviews.builder()
+                        .challenge(c)
+                        .user(user)
+                        .rating(req.getRating())
+                        .content(req.getContent())
+                        .build()
+        );
+
+        return toReviewDto(review);
+    }
 }

--- a/src/main/java/snapmeal/snapmeal/web/controller/ChallengeController.java
+++ b/src/main/java/snapmeal/snapmeal/web/controller/ChallengeController.java
@@ -28,7 +28,7 @@ public class ChallengeController {
     @Operation(summary = "내 챌린지 목록 조회")
     @GetMapping("/my")
     public List<ChallengeDto.Response> listMine(
-            @RequestParam(required = false, defaultValue = "IN_PROGRESS,SUCCESS,PENDING,FAIL") String statuses
+            @RequestParam(required = false, defaultValue = "IN_PROGRESS,SUCCESS,PENDING,FAIL,CANCELLED,NOT_PARTICIPATED") String statuses
     ) {
         // 서비스에서 stamps/satisfiedDays/introduction/participation까지 채워진 DTO 리턴
         return challengeService.listMineWithStamps(statuses);
@@ -205,7 +205,7 @@ public class ChallengeController {
                     content = @Content(mediaType = "application/json")
             )
     })
-    @PostMapping("/{challengeId}/reviews")
+    @PostMapping("/reviews/{challengeId}")
     public ChallengeDto.Response.ReviewResponse createReview(
             @PathVariable Long challengeId,
             @RequestBody ChallengeDto.Response.ReviewCreateOrUpdateRequest request
@@ -290,4 +290,35 @@ public class ChallengeController {
         challengeService.deleteReview(reviewId);
         return ResponseEntity.noContent().build();
     }
+
+    @Operation(summary = "챌린지 리뷰 조회(1개)")
+    @GetMapping("/reviews/{challengeId}")
+    public ChallengeDto.Response.ReviewResponse getReview(
+            @PathVariable Long challengeId
+    ) {
+        return challengeService.getReview(challengeId);
+    }
+
+    @Operation(
+            summary = "내가 작성한 챌린지 리뷰 전체 조회",
+            description = "로그인한 사용자가 작성한 모든 챌린지 리뷰를 최신순으로 조회합니다."
+    )
+    @GetMapping("/reviews/my")
+    public List<ChallengeDto.Response.ReviewResponse> listMyReviews() {
+        return challengeService.listMyReviews();
+    }
+
+    // 테스트 용 (데이터를 넣기 위함이므로, 테스트 후 삭제)
+    @Operation(
+            summary = "⚠️ 테스트용 챌린지 리뷰 작성 (기간/상태 무시)",
+            description = "기간이 끝나지 않아도 리뷰를 강제로 생성합니다. 실제 운영에서는 사용 X"
+    )
+    @PostMapping("/{challengeId}/reviews/test")
+    public ChallengeDto.Response.ReviewResponse createReviewForTest(
+            @PathVariable Long challengeId,
+            @RequestBody ChallengeDto.Response.ReviewCreateOrUpdateRequest req
+    ) {
+        return challengeService.createReviewForTest(challengeId, req);
+    }
+
 }


### PR DESCRIPTION
## 📝작업 내용

> 챌린지 기간 종료 시 실패로 뜨는 오류 수정 -> 챌린지 미참여 상태 추가 (NOT_PARTICIPATED)
> 챌린지 취소 상태 추가 (CANCELLED) ← 재참여 불가
> 챌린지 리뷰 단일 조회 추가
> 챌린지 리뷰 전체 조회 추가

> 테스트용 챌린지 리뷰 작성 코드 추가 (기간, 참여 여부 관계 없이 강제로 생성)

### 스크린샷 
<img width="724" height="425" alt="image" src="https://github.com/user-attachments/assets/87f9cd57-a494-49d4-8f7d-309b1dd761de" />

<img width="720" height="491" alt="image" src="https://github.com/user-attachments/assets/abb1e802-6346-4258-a8f5-1a73d84df9c7" />

<img width="719" height="720" alt="image" src="https://github.com/user-attachments/assets/2fbae93b-4a42-4957-9f97-5198388df788" />

