### PR TITLE
Fix: 이미지 업로드 및 예측 시 sodium 0인 문제 해결

### DIFF
--- a/src/main/java/snapmeal/snapmeal/global/util/OpenAiConverter.java
+++ b/src/main/java/snapmeal/snapmeal/global/util/OpenAiConverter.java
@@ -33,6 +33,7 @@ public class OpenAiConverter {
                 - carbs (실수, g)
                 - sugar (실수, g)
                 - fat (실수, g)
+                - sodium (실수, g)
                 
                 **반드시** JSON 배열 형식으로만 응답해야 해.
                 아래와 같은 형식을 따라야 해:
@@ -44,7 +45,8 @@ public class OpenAiConverter {
                     "protein": 12.5,
                     "carbs": 30,
                     "sugar": 4.5,
-                    "fat": 10
+                    "fat": 10,
+                    "sodium": 2,
                   }
                 ]
                 


### PR DESCRIPTION

## 📝작업 내용

> 이미지 업로드 및 예측에서 식사기록으로 넘어갈 때 sodium 값이 0인 문제 해결

### 스크린샷 (선택)

<img width="524" height="297" alt="image" src="https://github.com/user-attachments/assets/e0ab5344-3995-4129-9dbd-a7a7e9e8f3a5" />
